### PR TITLE
feat: add remote-exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "shlex",
  "thiserror 1.0.69",
  "tokio",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -200,6 +206,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -403,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +440,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -879,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -958,6 +987,30 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]
@@ -1051,6 +1104,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,7 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -1146,7 +1220,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1234,7 +1308,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1438,6 +1512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1530,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1539,7 +1640,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1772,7 +1873,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -1879,6 +1980,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "libc",
+ "nix 0.29.0",
+ "portable-pty",
  "rand 0.8.5",
  "reqwest",
  "rustls",
@@ -1972,18 +2076,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1994,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2004,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2014,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2027,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2049,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2075,6 +2179,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2277,10 +2403,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
+name = "winreg"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,10 @@ bytes = "1.7"
 arc-swap = "1"
 shlex = "1.3"
 
-# Remote exec (PTY)
+# Remote exec (PTY) — Unix only; `mod exec` is `#[cfg(unix)]` and the server
+# Exec handler rejects the message on non-unix.
+libc = "0.2"
+
+[target.'cfg(unix)'.dependencies]
 portable-pty = "0.9"
 nix = { version = "0.29", features = ["term"] }
-libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,8 @@ base64ct = { version = "1.6", features = ["alloc"] }
 futures = "0.3"
 bytes = "1.7"
 arc-swap = "1"
+
+# Remote exec (PTY)
+portable-pty = "0.9"
+nix = { version = "0.29", features = ["term"] }
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,9 @@ bytes = "1.7"
 arc-swap = "1"
 shlex = "1.3"
 
+[target.'cfg(unix)'.dependencies]
 # Remote exec (PTY) — Unix only; `mod exec` is `#[cfg(unix)]` and the server
 # Exec handler rejects the message on non-unix.
 libc = "0.2"
-
-[target.'cfg(unix)'.dependencies]
 portable-pty = "0.9"
-nix = { version = "0.29", features = ["term"] }
+nix = { version = "0.29", features = ["fs", "term"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ base64ct = { version = "1.6", features = ["alloc"] }
 futures = "0.3"
 bytes = "1.7"
 arc-swap = "1"
+shlex = "1.3"
 
 # Remote exec (PTY)
 portable-pty = "0.9"

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,6 +30,12 @@ password = "change-this-to-a-strong-password"
 # Connection timeout in seconds (optional)
 # timeout = 300
 
+# Allow `tunnix remote-exec` to open an interactive shell / run commands on THIS
+# machine. WARNING: this is remote code execution — anyone with the password can
+# run a shell here. Only enable on a box you control. Disabled by default.
+# Can also be enabled with the server flag --allow-exec.
+# allow_exec = false
+
 [client]
 # Server URL. If the server uses a path_prefix, include it here.
 # Examples:

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,12 @@ pub struct ServerConfig {
     /// Response body for GET /health (default: "ok").
     #[serde(default = "default_health_response")]
     pub health_response: String,
+
+    /// Allow remote command execution (`tunnix remote-exec`). This exposes an
+    /// interactive shell on this machine to anyone holding the password — i.e.
+    /// remote code execution. Disabled by default.
+    #[serde(default)]
+    pub allow_exec: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -127,6 +133,7 @@ impl Default for ServerConfig {
             root_redirect: None,
             root_html: None,
             health_response: default_health_response(),
+            allow_exec: false,
         }
     }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -18,12 +18,15 @@ fn stdin_fd() -> BorrowedFd<'static> {
 /// Current terminal size as (cols, rows), defaulting to 80x24 if unavailable.
 fn terminal_size() -> (u16, u16) {
     let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::ioctl(libc::STDIN_FILENO, libc::TIOCGWINSZ, &mut ws) };
-    if rc == 0 && ws.ws_col > 0 && ws.ws_row > 0 {
-        (ws.ws_col, ws.ws_row)
-    } else {
-        (80, 24)
+    // stdin may be redirected (piped input) while stdout/stderr is still a TTY,
+    // so fall back across all three before defaulting.
+    for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+        let rc = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
+        if rc == 0 && ws.ws_col > 0 && ws.ws_row > 0 {
+            return (ws.ws_col, ws.ws_row);
+        }
     }
+    (80, 24)
 }
 
 /// Puts the terminal into raw mode and restores the original settings on drop

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -93,17 +93,27 @@ async fn session(
     // Only a real ExitStatus from the server makes the command's exit code
     // meaningful. If the tunnel drops or errors first, we must not report 0.
     let mut saw_exit = false;
+    // Whether we've forwarded any stdin bytes to the remote PTY.
+    let mut sent_input = false;
 
     loop {
         tokio::select! {
             n = stdin.read(&mut stdin_buf), if stdin_open => {
                 match n {
                     Ok(0) => {
-                        // Real stdin EOF (e.g. piped input ended). Stop forwarding
-                        // input but keep relaying output until the process exits.
+                        // Local stdin hit EOF. If we actually sent input, signal EOF
+                        // to the remote PTY with the terminal EOF byte (Ctrl-D/VEOF)
+                        // so canonical-mode consumers (cat, read, filters) terminate.
+                        // Skip it when nothing was sent (e.g. `cmd </dev/null`) to
+                        // avoid a stray ^D echo for commands that ignore stdin.
+                        if sent_input {
+                            let eof = Message::Data { conn_id, data: vec![0x04] };
+                            let _ = tunnel.send_message(&eof).await;
+                        }
                         stdin_open = false;
                     }
                     Ok(n) => {
+                        sent_input = true;
                         let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
                         if let Err(e) = tunnel.send_message(&msg).await {
                             anyhow::bail!("stdin send failed: {}", e);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -75,92 +75,98 @@ async fn session(
 ) -> Result<i32> {
     let (cols, rows) = terminal_size();
 
-    // Ask the server to open the PTY; the ACK is empty Data on success, or an
-    // Error (e.g. exec disabled) which we surface before touching the terminal.
-    let exec_msg = Message::Exec { conn_id, cmd, cols, rows };
-    if let Some(Message::Error { message, .. }) = tunnel.send_connect(&exec_msg).await? {
-        anyhow::bail!("{}", message);
-    }
+    // Run the session body in an inner async block so we can guarantee a
+    // `Message::Close` is sent to the server on every exit path (including
+    // `?` early returns). Without this, a tunnel error during the session
+    // would leave the server's PTY and child process orphaned.
+    let result = async {
+        // Ask the server to open the PTY; the ACK is empty Data on success, or an
+        // Error (e.g. exec disabled) which we surface before touching the terminal.
+        let exec_msg = Message::Exec { conn_id, cmd, cols, rows };
+        if let Some(Message::Error { message, .. }) = tunnel.send_connect(&exec_msg).await? {
+            anyhow::bail!("{}", message);
+        }
 
-    // PTY is live — switch the local terminal to raw mode so keystrokes and
-    // control sequences pass through untouched. Best-effort: when stdin is not a
-    // TTY (piped / redirected), we just stream without raw mode.
-    let _guard = RawGuard::enter().ok();
+        // PTY is live — switch the local terminal to raw mode so keystrokes and
+        // control sequences pass through untouched. Best-effort: when stdin is not a
+        // TTY (piped / redirected), we just stream without raw mode.
+        let _guard = RawGuard::enter().ok();
 
-    let mut stdin = tokio::io::stdin();
-    let mut stdout = tokio::io::stdout();
-    let mut stdin_buf = vec![0u8; 8192];
-    let mut stdin_open = true;
-    let mut winch = signal(SignalKind::window_change())?;
-    let mut exit_code = 0;
-    // Only a real ExitStatus from the server makes the command's exit code
-    // meaningful. If the tunnel drops or errors first, we must not report 0.
-    let mut saw_exit = false;
-    // Whether we've forwarded any stdin bytes to the remote PTY.
-    let mut sent_input = false;
+        let mut stdin = tokio::io::stdin();
+        let mut stdout = tokio::io::stdout();
+        let mut stdin_buf = vec![0u8; 8192];
+        let mut stdin_open = true;
+        let mut winch = signal(SignalKind::window_change())?;
+        let mut exit_code = 0;
+        // Only a real ExitStatus from the server makes the command's exit code
+        // meaningful. If the tunnel drops or errors first, we must not report 0.
+        let mut saw_exit = false;
 
-    loop {
-        tokio::select! {
-            n = stdin.read(&mut stdin_buf), if stdin_open => {
-                match n {
-                    Ok(0) => {
-                        // Local stdin hit EOF. If we actually sent input, signal EOF
-                        // to the remote PTY with the terminal EOF byte (Ctrl-D/VEOF)
-                        // so canonical-mode consumers (cat, read, filters) terminate.
-                        // Skip it when nothing was sent (e.g. `cmd </dev/null`) to
-                        // avoid a stray ^D echo for commands that ignore stdin.
-                        if sent_input {
+        loop {
+            tokio::select! {
+                n = stdin.read(&mut stdin_buf), if stdin_open => {
+                    match n {
+                        Ok(0) => {
+                            // Local stdin hit EOF. Always signal EOF to the
+                            // remote PTY with the terminal EOF byte (Ctrl-D /
+                            // VEOF) so canonical-mode consumers (cat, read,
+                            // filters) terminate. Skipping this when the local
+                            // stream was already empty (e.g. `cmd </dev/null`)
+                            // would hang commands that wait for stdin to close.
                             let eof = Message::Data { conn_id, data: vec![0x04] };
                             let _ = tunnel.send_message(&eof).await;
+                            stdin_open = false;
                         }
-                        stdin_open = false;
-                    }
-                    Ok(n) => {
-                        sent_input = true;
-                        let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
-                        if let Err(e) = tunnel.send_message(&msg).await {
-                            anyhow::bail!("stdin send failed: {}", e);
+                        Ok(n) => {
+                            let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
+                            if let Err(e) = tunnel.send_message(&msg).await {
+                                anyhow::bail!("stdin send failed: {}", e);
+                            }
                         }
-                    }
-                    Err(e) => {
-                        debug!("stdin read error: {}", e);
-                        stdin_open = false;
+                        Err(e) => {
+                            debug!("stdin read error: {}", e);
+                            stdin_open = false;
+                        }
                     }
                 }
-            }
-            event = event_rx.recv() => {
-                match event {
-                    Some(TunnelEvent::Data(data)) => {
-                        if stdout.write_all(&data).await.is_err() {
-                            break;
+                event = event_rx.recv() => {
+                    match event {
+                        Some(TunnelEvent::Data(data)) => {
+                            if stdout.write_all(&data).await.is_err() {
+                                break;
+                            }
+                            let _ = stdout.flush().await;
                         }
-                        let _ = stdout.flush().await;
+                        Some(TunnelEvent::Exit(code)) => {
+                            exit_code = code;
+                            saw_exit = true;
+                        }
+                        Some(TunnelEvent::Error(msg)) => {
+                            anyhow::bail!("remote error: {}", msg);
+                        }
+                        Some(TunnelEvent::Close) | None => break,
                     }
-                    Some(TunnelEvent::Exit(code)) => {
-                        exit_code = code;
-                        saw_exit = true;
-                    }
-                    Some(TunnelEvent::Error(msg)) => {
-                        anyhow::bail!("remote error: {}", msg);
-                    }
-                    Some(TunnelEvent::Close) | None => break,
                 }
-            }
-            _ = winch.recv() => {
-                let (cols, rows) = terminal_size();
-                let _ = tunnel
-                    .send_message(&Message::Resize { conn_id, cols, rows })
-                    .await;
+                _ = winch.recv() => {
+                    let (cols, rows) = terminal_size();
+                    let _ = tunnel
+                        .send_message(&Message::Resize { conn_id, cols, rows })
+                        .await;
+                }
             }
         }
-    }
 
+        if saw_exit {
+            Ok(exit_code)
+        } else {
+            anyhow::bail!("connection closed before the remote command reported an exit status");
+        }
+    }
+    .await;
+
+    // Always tell the server to tear down the PTY, even on early bail — the
+    // server-side relay will then kill the child via the closed writer channel.
     let _ = tunnel.send_message(&Message::Close { conn_id }).await;
-    // _guard drops here, restoring the terminal before we return.
-
-    if saw_exit {
-        Ok(exit_code)
-    } else {
-        anyhow::bail!("connection closed before the remote command reported an exit status");
-    }
+    // _guard drops here on the success path, restoring the terminal.
+    result
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -92,6 +92,20 @@ async fn session(
         // TTY (piped / redirected), we just stream without raw mode.
         let _guard = RawGuard::enter().ok();
 
+        // Dedicated background sender: all outbound messages (stdin data, EOF,
+        // resize) are queued into the mpsc and shipped by this task. Keeps the
+        // select! arms non-blocking so a slow POST /send can't stall stdout
+        // writes or SIGWINCH handling.
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let sender_tunnel = tunnel.clone();
+        let sender_task = tokio::spawn(async move {
+            while let Some(msg) = msg_rx.recv().await {
+                if let Err(e) = sender_tunnel.send_message(&msg).await {
+                    debug!("send_message failed: {}", e);
+                }
+            }
+        });
+
         let mut stdin = tokio::io::stdin();
         let mut stdout = tokio::io::stdout();
         let mut stdin_buf = vec![0u8; 8192];
@@ -101,26 +115,37 @@ async fn session(
         // Only a real ExitStatus from the server makes the command's exit code
         // meaningful. If the tunnel drops or errors first, we must not report 0.
         let mut saw_exit = false;
+        // Track whether the last forwarded byte was '\n'. On local stdin EOF,
+        // canonical-mode consumers (cat, read, ...) need a real EOF, not just a
+        // VEOF flush of an unterminated pending line. If the line is still
+        // buffered (no trailing newline), one Ctrl-D only delivers the partial
+        // line; the consumer then waits for more input forever. We send
+        // '\n' + 0x04 in that case so the line is delivered AND the next read
+        // sees EOF.
+        let mut last_was_newline = true;
 
         loop {
             tokio::select! {
                 n = stdin.read(&mut stdin_buf), if stdin_open => {
                     match n {
                         Ok(0) => {
-                            // Local stdin hit EOF. Always signal EOF to the
-                            // remote PTY with the terminal EOF byte (Ctrl-D /
-                            // VEOF) so canonical-mode consumers (cat, read,
-                            // filters) terminate. Skipping this when the local
-                            // stream was already empty (e.g. `cmd </dev/null`)
-                            // would hang commands that wait for stdin to close.
-                            let eof = Message::Data { conn_id, data: vec![0x04] };
-                            let _ = tunnel.send_message(&eof).await;
+                            // Local stdin hit EOF. Send a real EOF to the
+                            // remote PTY so canonical-mode consumers terminate.
+                            let mut eof_data = Vec::with_capacity(2);
+                            if !last_was_newline {
+                                // Terminate the pending line so the VEOF below
+                                // can actually signal EOF on an empty buffer.
+                                eof_data.push(b'\n');
+                            }
+                            eof_data.push(0x04);
+                            let _ = msg_tx.send(Message::Data { conn_id, data: eof_data });
                             stdin_open = false;
                         }
                         Ok(n) => {
+                            last_was_newline = stdin_buf[n - 1] == b'\n';
                             let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
-                            if let Err(e) = tunnel.send_message(&msg).await {
-                                anyhow::bail!("stdin send failed: {}", e);
+                            if msg_tx.send(msg).is_err() {
+                                anyhow::bail!("sender channel closed");
                             }
                         }
                         Err(e) => {
@@ -149,12 +174,16 @@ async fn session(
                 }
                 _ = winch.recv() => {
                     let (cols, rows) = terminal_size();
-                    let _ = tunnel
-                        .send_message(&Message::Resize { conn_id, cols, rows })
-                        .await;
+                    let _ = msg_tx.send(Message::Resize { conn_id, cols, rows });
                 }
             }
         }
+
+        // Close the sender channel and wait for it to flush all queued
+        // messages. This guarantees the final Message::Close below is the
+        // last thing sent on the wire for this conn_id.
+        drop(msg_tx);
+        let _ = sender_task.await;
 
         if saw_exit {
             Ok(exit_code)

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -102,6 +102,7 @@ async fn session(
             while let Some(msg) = msg_rx.recv().await {
                 if let Err(e) = sender_tunnel.send_message(&msg).await {
                     debug!("send_message failed: {}", e);
+                    break;
                 }
             }
         });

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::os::fd::BorrowedFd;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::signal::unix::{signal, SignalKind};
@@ -8,12 +7,6 @@ use tracing::debug;
 use crate::protocol::Message;
 use crate::relay::next_conn_id;
 use crate::tunnel::{Tunnel, TunnelEvent};
-
-/// stdin as a BorrowedFd (fd 0).
-fn stdin_fd() -> BorrowedFd<'static> {
-    // SAFETY: fd 0 is valid for the lifetime of the process.
-    unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) }
-}
 
 /// Current terminal size as (cols, rows), defaulting to 80x24 if unavailable.
 fn terminal_size() -> (u16, u16) {
@@ -38,7 +31,9 @@ struct RawGuard {
 impl RawGuard {
     fn enter() -> Result<Self> {
         use nix::sys::termios::{cfmakeraw, tcgetattr, tcsetattr, SetArg};
-        let fd = stdin_fd();
+        use std::os::fd::AsFd;
+        let stdin = std::io::stdin();
+        let fd = stdin.as_fd();
         let original = tcgetattr(fd)?;
         let mut raw = original.clone();
         cfmakeraw(&mut raw);
@@ -50,7 +45,8 @@ impl RawGuard {
 impl Drop for RawGuard {
     fn drop(&mut self) {
         use nix::sys::termios::{tcsetattr, SetArg};
-        let _ = tcsetattr(stdin_fd(), SetArg::TCSANOW, &self.original);
+        use std::os::fd::AsFd;
+        let _ = tcsetattr(std::io::stdin().as_fd(), SetArg::TCSANOW, &self.original);
     }
 }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -3,7 +3,7 @@ use std::os::fd::BorrowedFd;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::signal::unix::{signal, SignalKind};
-use tracing::{debug, error};
+use tracing::debug;
 
 use crate::protocol::Message;
 use crate::relay::next_conn_id;
@@ -57,13 +57,25 @@ pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
     let conn_id = next_conn_id();
     let mut event_rx = tunnel.register_connection(conn_id).await;
 
+    // Run the session in an inner block so the connection is always unregistered,
+    // even on an early error return.
+    let result = session(&tunnel, conn_id, &mut event_rx, cmd).await;
+    tunnel.unregister_connection(conn_id).await;
+    result
+}
+
+async fn session(
+    tunnel: &Arc<Tunnel>,
+    conn_id: u32,
+    event_rx: &mut tokio::sync::mpsc::Receiver<TunnelEvent>,
+    cmd: Option<String>,
+) -> Result<i32> {
     let (cols, rows) = terminal_size();
 
     // Ask the server to open the PTY; the ACK is empty Data on success, or an
     // Error (e.g. exec disabled) which we surface before touching the terminal.
     let exec_msg = Message::Exec { conn_id, cmd, cols, rows };
     if let Some(Message::Error { message, .. }) = tunnel.send_connect(&exec_msg).await? {
-        tunnel.unregister_connection(conn_id).await;
         anyhow::bail!("{}", message);
     }
 
@@ -78,6 +90,9 @@ pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
     let mut stdin_open = true;
     let mut winch = signal(SignalKind::window_change())?;
     let mut exit_code = 0;
+    // Only a real ExitStatus from the server makes the command's exit code
+    // meaningful. If the tunnel drops or errors first, we must not report 0.
+    let mut saw_exit = false;
 
     loop {
         tokio::select! {
@@ -91,8 +106,7 @@ pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
                     Ok(n) => {
                         let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
                         if let Err(e) = tunnel.send_message(&msg).await {
-                            error!("stdin send error: {}", e);
-                            break;
+                            anyhow::bail!("stdin send failed: {}", e);
                         }
                     }
                     Err(e) => {
@@ -111,10 +125,10 @@ pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
                     }
                     Some(TunnelEvent::Exit(code)) => {
                         exit_code = code;
+                        saw_exit = true;
                     }
                     Some(TunnelEvent::Error(msg)) => {
-                        debug!("remote error: {}", msg);
-                        break;
+                        anyhow::bail!("remote error: {}", msg);
                     }
                     Some(TunnelEvent::Close) | None => break,
                 }
@@ -129,7 +143,11 @@ pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
     }
 
     let _ = tunnel.send_message(&Message::Close { conn_id }).await;
-    tunnel.unregister_connection(conn_id).await;
     // _guard drops here, restoring the terminal before we return.
-    Ok(exit_code)
+
+    if saw_exit {
+        Ok(exit_code)
+    } else {
+        anyhow::bail!("connection closed before the remote command reported an exit status");
+    }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -78,7 +78,8 @@ async fn session(
     let result = async {
         // Ask the server to open the PTY; the ACK is empty Data on success, or an
         // Error (e.g. exec disabled) which we surface before touching the terminal.
-        let exec_msg = Message::Exec { conn_id, cmd, cols, rows };
+        let term = std::env::var("TERM").unwrap_or_else(|_| "xterm-256color".to_string());
+        let exec_msg = Message::Exec { conn_id, cmd, cols, rows, term };
         if let Some(Message::Error { message, .. }) = tunnel.send_connect(&exec_msg).await? {
             anyhow::bail!("{}", message);
         }
@@ -102,6 +103,11 @@ async fn session(
                 }
             }
         });
+        // Poll the sender in the select! below. send_message already retries
+        // across a forced SSE reconnect, so if it returns an error the task
+        // breaks and exits — a persistent outbound failure. Detect that here
+        // instead of silently dropping the user's keystrokes into a dead task.
+        tokio::pin!(sender_task);
 
         let mut stdin = tokio::io::stdin();
         let mut stdout = tokio::io::stdout();
@@ -123,6 +129,12 @@ async fn session(
 
         loop {
             tokio::select! {
+                _res = &mut sender_task => {
+                    // The sender only exits on a persistent send failure (its
+                    // loop runs until msg_tx is dropped at teardown, which
+                    // hasn't happened yet). Treat it as a dead tunnel.
+                    anyhow::bail!("outbound sender task exited; tunnel is down");
+                }
                 n = stdin.read(&mut stdin_buf), if stdin_open => {
                     match n {
                         Ok(0) => {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,0 +1,135 @@
+use anyhow::Result;
+use std::os::fd::BorrowedFd;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::signal::unix::{signal, SignalKind};
+use tracing::{debug, error};
+
+use crate::protocol::Message;
+use crate::relay::next_conn_id;
+use crate::tunnel::{Tunnel, TunnelEvent};
+
+/// stdin as a BorrowedFd (fd 0).
+fn stdin_fd() -> BorrowedFd<'static> {
+    // SAFETY: fd 0 is valid for the lifetime of the process.
+    unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) }
+}
+
+/// Current terminal size as (cols, rows), defaulting to 80x24 if unavailable.
+fn terminal_size() -> (u16, u16) {
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::ioctl(libc::STDIN_FILENO, libc::TIOCGWINSZ, &mut ws) };
+    if rc == 0 && ws.ws_col > 0 && ws.ws_row > 0 {
+        (ws.ws_col, ws.ws_row)
+    } else {
+        (80, 24)
+    }
+}
+
+/// Puts the terminal into raw mode and restores the original settings on drop
+/// (return, error, or panic).
+struct RawGuard {
+    original: nix::sys::termios::Termios,
+}
+
+impl RawGuard {
+    fn enter() -> Result<Self> {
+        use nix::sys::termios::{cfmakeraw, tcgetattr, tcsetattr, SetArg};
+        let fd = stdin_fd();
+        let original = tcgetattr(fd)?;
+        let mut raw = original.clone();
+        cfmakeraw(&mut raw);
+        tcsetattr(fd, SetArg::TCSANOW, &raw)?;
+        Ok(Self { original })
+    }
+}
+
+impl Drop for RawGuard {
+    fn drop(&mut self) {
+        use nix::sys::termios::{tcsetattr, SetArg};
+        let _ = tcsetattr(stdin_fd(), SetArg::TCSANOW, &self.original);
+    }
+}
+
+/// Run a remote command (or interactive shell when `cmd` is None) over the tunnel,
+/// wiring the local terminal to a PTY on the server. Returns the child's exit code.
+pub async fn run(tunnel: Arc<Tunnel>, cmd: Option<String>) -> Result<i32> {
+    let conn_id = next_conn_id();
+    let mut event_rx = tunnel.register_connection(conn_id).await;
+
+    let (cols, rows) = terminal_size();
+
+    // Ask the server to open the PTY; the ACK is empty Data on success, or an
+    // Error (e.g. exec disabled) which we surface before touching the terminal.
+    let exec_msg = Message::Exec { conn_id, cmd, cols, rows };
+    if let Some(Message::Error { message, .. }) = tunnel.send_connect(&exec_msg).await? {
+        tunnel.unregister_connection(conn_id).await;
+        anyhow::bail!("{}", message);
+    }
+
+    // PTY is live — switch the local terminal to raw mode so keystrokes and
+    // control sequences pass through untouched. Best-effort: when stdin is not a
+    // TTY (piped / redirected), we just stream without raw mode.
+    let _guard = RawGuard::enter().ok();
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    let mut stdin_buf = vec![0u8; 8192];
+    let mut stdin_open = true;
+    let mut winch = signal(SignalKind::window_change())?;
+    let mut exit_code = 0;
+
+    loop {
+        tokio::select! {
+            n = stdin.read(&mut stdin_buf), if stdin_open => {
+                match n {
+                    Ok(0) => {
+                        // Real stdin EOF (e.g. piped input ended). Stop forwarding
+                        // input but keep relaying output until the process exits.
+                        stdin_open = false;
+                    }
+                    Ok(n) => {
+                        let msg = Message::Data { conn_id, data: stdin_buf[..n].to_vec() };
+                        if let Err(e) = tunnel.send_message(&msg).await {
+                            error!("stdin send error: {}", e);
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        debug!("stdin read error: {}", e);
+                        stdin_open = false;
+                    }
+                }
+            }
+            event = event_rx.recv() => {
+                match event {
+                    Some(TunnelEvent::Data(data)) => {
+                        if stdout.write_all(&data).await.is_err() {
+                            break;
+                        }
+                        let _ = stdout.flush().await;
+                    }
+                    Some(TunnelEvent::Exit(code)) => {
+                        exit_code = code;
+                    }
+                    Some(TunnelEvent::Error(msg)) => {
+                        debug!("remote error: {}", msg);
+                        break;
+                    }
+                    Some(TunnelEvent::Close) | None => break,
+                }
+            }
+            _ = winch.recv() => {
+                let (cols, rows) = terminal_size();
+                let _ = tunnel
+                    .send_message(&Message::Resize { conn_id, cols, rows })
+                    .await;
+            }
+        }
+    }
+
+    let _ = tunnel.send_message(&Message::Close { conn_id }).await;
+    tunnel.unregister_connection(conn_id).await;
+    // _guard drops here, restoring the terminal before we return.
+    Ok(exit_code)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod crypto;
+#[cfg(unix)]
 mod exec;
 mod http_proxy;
 mod protocol;
@@ -47,6 +48,7 @@ enum Command {
     /// Run the client
     Client(ClientArgs),
     /// Run a command (or interactive shell) on the server (requires server allow_exec)
+    #[cfg(unix)]
     RemoteExec(RemoteExecArgs),
 }
 
@@ -84,6 +86,7 @@ struct ClientArgs {
     cookie: Option<String>,
 }
 
+#[cfg(unix)]
 #[derive(clap::Args, Debug)]
 struct RemoteExecArgs {
     /// Server URL (overrides config)
@@ -126,12 +129,14 @@ async fn main() -> Result<()> {
         None => Config::from_file("config.toml").unwrap_or_default(),
     };
 
+    #[cfg_attr(not(unix), allow(unused_variables))]
     let explicit_log_level = args.log_level.is_some();
     if let Some(log_level) = args.log_level {
         config.logging.level = log_level;
     }
     // Keep the terminal clean during an interactive remote-exec session unless
     // the user explicitly asked for a log level.
+    #[cfg(unix)]
     if matches!(args.command, Command::RemoteExec(_)) && !explicit_log_level {
         config.logging.level = "error".to_string();
     }
@@ -173,6 +178,7 @@ async fn main() -> Result<()> {
         Command::Server(sa) => {
             let cli_overrides = Arc::new(CliOverrides {
                 server_password: sa.password.is_some(),
+                server_allow_exec: sa.allow_exec,
                 client_password: false,
                 client_headers: false,
             });
@@ -228,6 +234,7 @@ async fn main() -> Result<()> {
         Command::Client(ca) => {
             let cli_overrides = Arc::new(CliOverrides {
                 server_password: false,
+                server_allow_exec: false,
                 client_password: ca.password.is_some(),
                 client_headers: ca.cookie.is_some(),
             });
@@ -295,6 +302,7 @@ async fn main() -> Result<()> {
             proxy::run_proxy(&config.client.local_addr, tun).await?;
         }
 
+        #[cfg(unix)]
         Command::RemoteExec(ra) => {
             if let Some(server) = ra.server {
                 config.client.server_url = server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,11 +337,19 @@ async fn main() -> Result<()> {
 
             let cmd = if ra.cmd.is_empty() {
                 None
+            } else if ra.cmd.len() == 1 {
+                // Single arg: pass verbatim so shell metacharacters
+                // (&&, |, $VAR, ...) reach the server's `sh -c` and are
+                // interpreted by the shell. shlex would otherwise wrap the
+                // whole string in single quotes, which makes `sh` try to
+                // execute a literal command named `echo $HOME && id`.
+                Some(ra.cmd.into_iter().next().unwrap())
             } else {
-                // Shell-quote each arg so spaces / quotes inside args survive
-                // the trip through the server's `sh -c`. A plain join(" ")
-                // would re-tokenize, e.g. `echo "a b" "c"` would become
-                // `echo a b c` and the server would see four args.
+                // Multiple args: shell-quote each so spaces / quotes inside
+                // args survive the trip through the server's `sh -c`. A
+                // plain join(" ") would re-tokenize, e.g. `echo "a b" "c"`
+                // would become `echo a b c` and the server would see four
+                // args.
                 Some(
                     shlex::try_join(ra.cmd.iter().map(String::as_str))
                         .unwrap_or_else(|_| ra.cmd.join(" ")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod crypto;
+mod exec;
 mod http_proxy;
 mod protocol;
 mod proxy;
@@ -12,7 +13,7 @@ mod tunnel;
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 use std::sync::Arc;
-use tracing::{info, Level};
+use tracing::{info, warn, Level};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -45,6 +46,8 @@ enum Command {
     Server(ServerArgs),
     /// Run the client
     Client(ClientArgs),
+    /// Run a command (or interactive shell) on the server (requires server allow_exec)
+    RemoteExec(RemoteExecArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -56,6 +59,10 @@ struct ServerArgs {
     /// Password for encryption (overrides config)
     #[arg(short, long, env = "TUNNIX_PASSWORD")]
     password: Option<String>,
+
+    /// Allow remote command execution (exposes a shell — RCE). Off unless set here or in config.
+    #[arg(long)]
+    allow_exec: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -75,6 +82,25 @@ struct ClientArgs {
     /// Custom cookie header (overrides config)
     #[arg(short, long)]
     cookie: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+struct RemoteExecArgs {
+    /// Server URL (overrides config)
+    #[arg(short, long)]
+    server: Option<String>,
+
+    /// Password for encryption (overrides config)
+    #[arg(short, long, env = "TUNNIX_PASSWORD")]
+    password: Option<String>,
+
+    /// Custom cookie header (overrides config)
+    #[arg(short, long)]
+    cookie: Option<String>,
+
+    /// Command to run; omit for an interactive shell
+    #[arg(trailing_var_arg = true)]
+    cmd: Vec<String>,
 }
 
 fn resolve_config_path(explicit: &Option<String>) -> Option<String> {
@@ -100,8 +126,14 @@ async fn main() -> Result<()> {
         None => Config::from_file("config.toml").unwrap_or_default(),
     };
 
+    let explicit_log_level = args.log_level.is_some();
     if let Some(log_level) = args.log_level {
         config.logging.level = log_level;
+    }
+    // Keep the terminal clean during an interactive remote-exec session unless
+    // the user explicitly asked for a log level.
+    if matches!(args.command, Command::RemoteExec(_)) && !explicit_log_level {
+        config.logging.level = "error".to_string();
     }
 
     let level = match config.logging.level.to_lowercase().as_str() {
@@ -151,6 +183,9 @@ async fn main() -> Result<()> {
             if let Some(password) = sa.password {
                 config.server.password = password;
             }
+            if sa.allow_exec {
+                config.server.allow_exec = true;
+            }
 
             if config.server.password.is_empty() {
                 bail!("Password is required. Set via --password, TUNNIX_PASSWORD env var, or config file.");
@@ -165,6 +200,9 @@ async fn main() -> Result<()> {
             if !config.server.path_prefix.is_empty() {
                 info!("Path prefix: {}", config.server.path_prefix);
             }
+            if config.server.allow_exec {
+                warn!("Remote command execution ENABLED — anyone with the password can run a shell on this machine");
+            }
 
             let crypto = Arc::new(Crypto::new(&config.server.password)?);
             info!("Encryption initialized");
@@ -175,6 +213,7 @@ async fn main() -> Result<()> {
                 root_redirect: config.server.root_redirect.clone(),
                 root_html: config.server.root_html.clone(),
                 health_body: config.server.health_response.clone(),
+                allow_exec: config.server.allow_exec,
             };
 
             server::run_server(
@@ -254,6 +293,48 @@ async fn main() -> Result<()> {
             }
 
             proxy::run_proxy(&config.client.local_addr, tun).await?;
+        }
+
+        Command::RemoteExec(ra) => {
+            if let Some(server) = ra.server {
+                config.client.server_url = server;
+            }
+            if let Some(password) = ra.password {
+                config.client.password = password;
+            }
+            if let Some(cookie) = ra.cookie {
+                config.client.headers.insert("Cookie".to_string(), cookie);
+            }
+
+            if config.client.server_url.is_empty() {
+                bail!("Server URL is required. Set via --server or config file.");
+            }
+            if config.client.password.is_empty() {
+                bail!("Password is required. Set via --password, TUNNIX_PASSWORD env var, or config file.");
+            }
+
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .expect("Failed to install rustls crypto provider");
+
+            let crypto = Arc::new(Crypto::new(&config.client.password)?);
+
+            let tun = tunnel::Tunnel::connect(
+                &config.client.server_url,
+                crypto,
+                &config.client.headers,
+                &config.client.health_expected,
+            )
+            .await?;
+
+            let cmd = if ra.cmd.is_empty() {
+                None
+            } else {
+                Some(ra.cmd.join(" "))
+            };
+
+            let code = exec::run(tun, cmd).await?;
+            std::process::exit(code);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,14 @@ async fn main() -> Result<()> {
             let cmd = if ra.cmd.is_empty() {
                 None
             } else {
-                Some(ra.cmd.join(" "))
+                // Shell-quote each arg so spaces / quotes inside args survive
+                // the trip through the server's `sh -c`. A plain join(" ")
+                // would re-tokenize, e.g. `echo "a b" "c"` would become
+                // `echo a b c` and the server would see four args.
+                Some(
+                    shlex::try_join(ra.cmd.iter().map(String::as_str))
+                        .unwrap_or_else(|_| ra.cmd.join(" ")),
+                )
             };
 
             let code = exec::run(tun, cmd).await?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -124,6 +124,17 @@ mod tests {
     }
 
     #[test]
+    fn test_reset_message() {
+        // Reset is a unit variant; make sure it round-trips and decodes back to
+        // Reset (not some other variant sharing a discriminant).
+        let bytes = Message::Reset.to_bytes().unwrap();
+        assert!(
+            matches!(Message::from_bytes(&bytes).unwrap(), Message::Reset),
+            "Reset did not round-trip"
+        );
+    }
+
+    #[test]
     fn test_exec_messages() {
         for msg in [
             Message::Exec { conn_id: 7, cmd: Some("ls /home".into()), cols: 80, rows: 24, term: "xterm-256color".into() },

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -47,6 +47,9 @@ pub enum Message {
         cmd: Option<String>,
         cols: u16,
         rows: u16,
+        /// Client's $TERM, so the remote PTY advertises the right terminal type
+        /// (falls back to xterm-256color client-side when unset).
+        term: String,
     },
 
     /// Client's terminal was resized; server applies the new size to the PTY.
@@ -123,8 +126,8 @@ mod tests {
     #[test]
     fn test_exec_messages() {
         for msg in [
-            Message::Exec { conn_id: 7, cmd: Some("ls /home".into()), cols: 80, rows: 24 },
-            Message::Exec { conn_id: 8, cmd: None, cols: 120, rows: 40 },
+            Message::Exec { conn_id: 7, cmd: Some("ls /home".into()), cols: 80, rows: 24, term: "xterm-256color".into() },
+            Message::Exec { conn_id: 8, cmd: None, cols: 120, rows: 40, term: "screen-256color".into() },
             Message::Resize { conn_id: 7, cols: 100, rows: 30 },
             Message::ExitStatus { conn_id: 7, code: 42 },
         ] {
@@ -132,12 +135,13 @@ mod tests {
             let decoded = Message::from_bytes(&bytes).unwrap();
             match (msg, decoded) {
                 (
-                    Message::Exec { conn_id: a, cmd: c1, cols: cl1, rows: r1 },
-                    Message::Exec { conn_id: b, cmd: c2, cols: cl2, rows: r2 },
+                    Message::Exec { conn_id: a, cmd: c1, cols: cl1, rows: r1, term: t1 },
+                    Message::Exec { conn_id: b, cmd: c2, cols: cl2, rows: r2, term: t2 },
                 ) => {
                     assert_eq!(a, b);
                     assert_eq!(c1, c2);
                     assert_eq!((cl1, r1), (cl2, r2));
+                    assert_eq!(t1, t2);
                 }
                 (
                     Message::Resize { conn_id: a, cols: cl1, rows: r1 },

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -37,6 +37,30 @@ pub enum Message {
     /// restart). Client must treat any existing conn_ids as orphaned and tear
     /// them down — the server knows nothing about them.
     Reset,
+
+    /// Client asks the server to open a PTY for this conn_id and run a command.
+    /// cmd = None => interactive login shell ($SHELL or /bin/sh); Some(s) => `sh -c s`.
+    /// cols/rows are the initial terminal size. The PTY's byte stream then flows
+    /// over the existing Data/Close messages, exactly like a TCP connection.
+    Exec {
+        conn_id: u32,
+        cmd: Option<String>,
+        cols: u16,
+        rows: u16,
+    },
+
+    /// Client's terminal was resized; server applies the new size to the PTY.
+    Resize {
+        conn_id: u32,
+        cols: u16,
+        rows: u16,
+    },
+
+    /// Server reports the child process exit code (sent just before Close).
+    ExitStatus {
+        conn_id: u32,
+        code: i32,
+    },
 }
 
 impl Message {
@@ -93,6 +117,44 @@ mod tests {
                 assert_eq!(decoded_data, data);
             }
             _ => panic!("Wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_exec_messages() {
+        for msg in [
+            Message::Exec { conn_id: 7, cmd: Some("ls /home".into()), cols: 80, rows: 24 },
+            Message::Exec { conn_id: 8, cmd: None, cols: 120, rows: 40 },
+            Message::Resize { conn_id: 7, cols: 100, rows: 30 },
+            Message::ExitStatus { conn_id: 7, code: 42 },
+        ] {
+            let bytes = msg.to_bytes().unwrap();
+            let decoded = Message::from_bytes(&bytes).unwrap();
+            match (msg, decoded) {
+                (
+                    Message::Exec { conn_id: a, cmd: c1, cols: cl1, rows: r1 },
+                    Message::Exec { conn_id: b, cmd: c2, cols: cl2, rows: r2 },
+                ) => {
+                    assert_eq!(a, b);
+                    assert_eq!(c1, c2);
+                    assert_eq!((cl1, r1), (cl2, r2));
+                }
+                (
+                    Message::Resize { conn_id: a, cols: cl1, rows: r1 },
+                    Message::Resize { conn_id: b, cols: cl2, rows: r2 },
+                ) => {
+                    assert_eq!(a, b);
+                    assert_eq!((cl1, r1), (cl2, r2));
+                }
+                (
+                    Message::ExitStatus { conn_id: a, code: c1 },
+                    Message::ExitStatus { conn_id: b, code: c2 },
+                ) => {
+                    assert_eq!(a, b);
+                    assert_eq!(c1, c2);
+                }
+                _ => panic!("Wrong message type"),
+            }
         }
     }
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -75,6 +75,10 @@ pub async fn relay(
                     debug!("[{}] tunnel error: {}", conn_id, msg);
                     break;
                 }
+                TunnelEvent::Exit(_) => {
+                    // Only meaningful for remote exec; a TCP relay never sees it.
+                    break;
+                }
             }
         }
     });

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -40,6 +40,10 @@ pub fn build_http_client(headers: &HashMap<String, String>) -> anyhow::Result<re
     }
     Ok(reqwest::Client::builder()
         .default_headers(default_headers)
+        // Intentional: deployments behind a corporate TLS-inspecting proxy
+        // (MITM CA) rely on this so the client trusts the proxy's re-signed
+        // cert. Do NOT remove without coordinating with operators using such
+        // proxies — they would otherwise fail every TLS handshake.
         .danger_accept_invalid_certs(true)
         .build()?)
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -10,6 +10,7 @@ use crate::crypto::Crypto;
 
 pub struct CliOverrides {
     pub server_password: bool,
+    pub server_allow_exec: bool,
     pub client_password: bool,
     pub client_headers: bool,
 }
@@ -140,7 +141,13 @@ pub async fn config_watcher_server(
         if health_body != current.health_body {
             changed.push("health_body");
         }
-        if sc.allow_exec != current.allow_exec {
+        // A CLI --allow-exec wins over the file, just like --password.
+        let allow_exec = if overrides.server_allow_exec {
+            current.allow_exec
+        } else {
+            sc.allow_exec
+        };
+        if allow_exec != current.allow_exec {
             changed.push("allow_exec");
         }
 
@@ -155,7 +162,7 @@ pub async fn config_watcher_server(
             root_redirect: sc.root_redirect.clone(),
             root_html: sc.root_html.clone(),
             health_body,
-            allow_exec: sc.allow_exec,
+            allow_exec,
         }));
 
         info!("Config reloaded: {}", changed.join(", "));

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -20,6 +20,7 @@ pub struct HotServerConfig {
     pub root_redirect: Option<String>,
     pub root_html: Option<String>,
     pub health_body: String,
+    pub allow_exec: bool,
 }
 
 pub struct HotClientConfig {
@@ -139,6 +140,9 @@ pub async fn config_watcher_server(
         if health_body != current.health_body {
             changed.push("health_body");
         }
+        if sc.allow_exec != current.allow_exec {
+            changed.push("allow_exec");
+        }
 
         if changed.is_empty() {
             continue;
@@ -151,6 +155,7 @@ pub async fn config_watcher_server(
             root_redirect: sc.root_redirect.clone(),
             root_html: sc.root_html.clone(),
             health_body,
+            allow_exec: sc.allow_exec,
         }));
 
         info!("Config reloaded: {}", changed.join(", "));

--- a/src/server.rs
+++ b/src/server.rs
@@ -388,7 +388,9 @@ async fn handle_send(
                     },
                 );
             }
-            info!("[{}] EXEC {} ({}x{})", conn_id, cmd.as_deref().unwrap_or("<shell>"), cols, rows);
+            info!("[{}] EXEC {} ({}x{})", conn_id, if cmd.is_some() { "cmd" } else { "<shell>" }, cols, rows);
+            // The command may contain secrets — keep it out of normal logs.
+            debug!("[{}] EXEC command: {}", conn_id, cmd.as_deref().unwrap_or("<shell>"));
 
             let pty_system = native_pty_system();
             let pair = match pty_system.openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 }) {
@@ -678,9 +680,16 @@ async fn relay_pty_connection(
         }
     };
 
-    // Child has exited. Drain any remaining output before reporting exit.
-    let _ = read_blocking.await;
-    let _ = forward_task.await;
+    // Child has exited. Drain any remaining output before reporting exit, but
+    // bound the wait: if a backgrounded process inherited the slave PTY, the
+    // master never sees EOF and the blocking reader would otherwise hang forever.
+    let drain = async {
+        let _ = read_blocking.await;
+        let _ = forward_task.await;
+    };
+    if tokio::time::timeout(Duration::from_secs(2), drain).await.is_err() {
+        debug!("[{}] PTY output drain timed out (background process holding the pty?)", conn_id);
+    }
 
     // Report exit code, then close the logical connection.
     for msg in [

--- a/src/server.rs
+++ b/src/server.rs
@@ -801,17 +801,20 @@ async fn relay_pty_connection(
     tokio::pin!(sse_dead);
 
     let mut resize_rx = resize_rx;
+    let mut client_gone = false;
     let code = loop {
         tokio::select! {
             res = &mut wait_handle => break res.unwrap_or(-1),
             _ = &mut write_task => {
                 // Client went away (Close removed the writer sender). Kill the child.
                 let _ = killer.kill();
+                client_gone = true;
                 break (&mut wait_handle).await.unwrap_or(-1);
             }
             _ = &mut sse_dead => {
                 debug!("[{}] SSE stream closed continuously; killing orphaned PTY child", conn_id);
                 let _ = killer.kill();
+                client_gone = true;
                 break (&mut wait_handle).await.unwrap_or(-1);
             }
             new_size = resize_rx.recv() => {
@@ -850,7 +853,11 @@ async fn relay_pty_connection(
         if let Ok(bytes) = msg.to_bytes() {
             if let Ok(encrypted) = crypto.encrypt(&bytes) {
                 let mut sent = false;
-                for _ in 0..50 {
+                // The client is already known gone (writer closed or SSE dead
+                // ≥6s past the reconnect window), so don't spin the full 5s
+                // reconnect retry — one best-effort attempt is enough.
+                let max_retries = if client_gone { 1 } else { 50 };
+                for _ in 0..max_retries {
                     let sse_tx = {
                         let sess = session.lock().await;
                         sess.sse_tx.clone()
@@ -861,7 +868,7 @@ async fn relay_pty_connection(
                     }
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
-                if !sent {
+                if !sent && !client_gone {
                     error!("[{}] failed to deliver shutdown message", conn_id);
                 }
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,8 +7,10 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Mutex};
@@ -23,7 +25,11 @@ type BoxBody = http_body_util::Either<
 >;
 
 struct Session {
+    /// Per-conn_id sink for client→target bytes. Covers both TCP connections and
+    /// PTYs (remote exec) — a PTY is just another duplex byte stream.
     tcp_writers: HashMap<u32, mpsc::Sender<Vec<u8>>>,
+    /// PTY masters kept alive per conn_id so we can apply terminal resizes.
+    pty_masters: HashMap<u32, Box<dyn MasterPty + Send>>,
     /// SSE channel: encrypted messages queued for streaming to client
     sse_tx: mpsc::Sender<Vec<u8>>,
 }
@@ -191,6 +197,7 @@ async fn handle_stream(session_id: &str, state: &ServerState) -> Response<BoxBod
             .or_insert_with(|| {
                 Arc::new(Mutex::new(Session {
                     tcp_writers: HashMap::new(),
+                    pty_masters: HashMap::new(),
                     sse_tx: sse_tx.clone(),
                 }))
             })
@@ -370,6 +377,98 @@ async fn handle_send(
             sess.tcp_writers.remove(&conn_id);
             ok_response("")
         }
+        Message::Exec { conn_id, cmd, cols, rows } => {
+            if !hot.allow_exec {
+                warn!("[{}] EXEC denied: remote exec disabled", conn_id);
+                return encrypted_response(
+                    &hot.crypto,
+                    &Message::Error {
+                        conn_id: Some(conn_id),
+                        message: "remote exec is disabled on this server".to_string(),
+                    },
+                );
+            }
+            info!("[{}] EXEC {} ({}x{})", conn_id, cmd.as_deref().unwrap_or("<shell>"), cols, rows);
+
+            let pty_system = native_pty_system();
+            let pair = match pty_system.openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 }) {
+                Ok(p) => p,
+                Err(e) => {
+                    error!("[{}] openpty failed: {}", conn_id, e);
+                    return encrypted_response(
+                        &hot.crypto,
+                        &Message::Error { conn_id: Some(conn_id), message: format!("openpty failed: {}", e) },
+                    );
+                }
+            };
+
+            let mut builder = match &cmd {
+                Some(c) => {
+                    let mut b = CommandBuilder::new("/bin/sh");
+                    b.arg("-c");
+                    b.arg(c);
+                    b
+                }
+                None => CommandBuilder::new(std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())),
+            };
+            builder.env("TERM", "xterm-256color");
+
+            let child = match pair.slave.spawn_command(builder) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!("[{}] spawn failed: {}", conn_id, e);
+                    return encrypted_response(
+                        &hot.crypto,
+                        &Message::Error { conn_id: Some(conn_id), message: format!("spawn failed: {}", e) },
+                    );
+                }
+            };
+            // Drop the slave handle so the master reader sees EOF once the child exits.
+            drop(pair.slave);
+
+            let reader = match pair.master.try_clone_reader() {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("[{}] clone reader failed: {}", conn_id, e);
+                    return encrypted_response(
+                        &hot.crypto,
+                        &Message::Error { conn_id: Some(conn_id), message: format!("pty reader failed: {}", e) },
+                    );
+                }
+            };
+            let writer = match pair.master.take_writer() {
+                Ok(w) => w,
+                Err(e) => {
+                    error!("[{}] take writer failed: {}", conn_id, e);
+                    return encrypted_response(
+                        &hot.crypto,
+                        &Message::Error { conn_id: Some(conn_id), message: format!("pty writer failed: {}", e) },
+                    );
+                }
+            };
+
+            let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(256);
+            {
+                let mut sess = session.lock().await;
+                sess.tcp_writers.insert(conn_id, write_tx);
+                sess.pty_masters.insert(conn_id, pair.master);
+            }
+
+            let crypto = hot.crypto.clone();
+            tokio::spawn(async move {
+                relay_pty_connection(conn_id, reader, writer, child, write_rx, session, crypto).await;
+            });
+
+            encrypted_response(&hot.crypto, &Message::Data { conn_id, data: vec![] })
+        }
+        Message::Resize { conn_id, cols, rows } => {
+            debug!("[{}] RESIZE {}x{}", conn_id, cols, rows);
+            let sess = session.lock().await;
+            if let Some(master) = sess.pty_masters.get(&conn_id) {
+                let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+            }
+            ok_response("")
+        }
         Message::Ping => {
             match make_encrypted_response(&hot.crypto, &Message::Pong) {
                 Ok(data) => Response::builder()
@@ -386,6 +485,22 @@ async fn handle_send(
 fn make_encrypted_response(crypto: &Crypto, msg: &Message) -> Result<Vec<u8>> {
     let bytes = msg.to_bytes()?;
     Ok(crypto.encrypt(&bytes)?)
+}
+
+/// Build an HTTP 200 response whose body is the encrypted, serialized `msg`
+/// (the same octet-stream ACK shape the Connect path uses).
+fn encrypted_response(crypto: &Crypto, msg: &Message) -> Response<BoxBody> {
+    match make_encrypted_response(crypto, msg) {
+        Ok(data) => Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/octet-stream")
+            .body(http_body_util::Either::Left(Full::new(Bytes::from(data))))
+            .unwrap(),
+        Err(e) => {
+            error!("Encrypt response error: {}", e);
+            ok_response("error")
+        }
+    }
 }
 
 /// Relay data between an already-connected TCP stream and the tunnel SSE/POST channels.
@@ -473,4 +588,121 @@ async fn relay_tcp_connection(
     }
 
     info!("[{}] Connection closed for {}:{}", conn_id, host, port);
+}
+
+/// Relay between a PTY (remote exec) and the tunnel SSE/POST channels.
+/// PTY readers/writers are blocking std::io, so the blocking halves run on
+/// `spawn_blocking` threads and bridge to async via channels — but the SSE send
+/// path mirrors `relay_tcp_connection` so it stays reconnection-aware.
+async fn relay_pty_connection(
+    conn_id: u32,
+    reader: Box<dyn Read + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    write_rx: mpsc::Receiver<Vec<u8>>,
+    session: Arc<Mutex<Session>>,
+    crypto: Arc<Crypto>,
+) {
+    // PTY -> SSE: blocking reader feeds a channel; an async task encrypts and
+    // forwards to the (possibly-reconnected) SSE sender.
+    let (pty_out_tx, mut pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
+    let read_blocking = tokio::task::spawn_blocking(move || {
+        let mut reader = reader;
+        let mut buf = vec![0u8; 32768];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if pty_out_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let crypto_fwd = crypto.clone();
+    let session_fwd = session.clone();
+    let forward_task = tokio::spawn(async move {
+        while let Some(data) = pty_out_rx.recv().await {
+            let msg = Message::Data { conn_id, data };
+            let bytes = match msg.to_bytes() {
+                Ok(b) => b,
+                Err(e) => { error!("[{}] PTY serialize: {}", conn_id, e); break; }
+            };
+            let encrypted = match crypto_fwd.encrypt(&bytes) {
+                Ok(e) => e,
+                Err(e) => { error!("[{}] PTY encrypt: {}", conn_id, e); break; }
+            };
+            let sse_tx = {
+                let sess = session_fwd.lock().await;
+                sess.sse_tx.clone()
+            };
+            if sse_tx.send(encrypted).await.is_err() {
+                debug!("[{}] SSE stream replaced or closed", conn_id);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    });
+
+    // client -> PTY: blocking writer fed by the per-conn write channel.
+    let write_blocking = tokio::task::spawn_blocking(move || {
+        let mut writer = writer;
+        let mut write_rx = write_rx;
+        while let Some(data) = write_rx.blocking_recv() {
+            if data.is_empty() {
+                continue;
+            }
+            if writer.write_all(&data).is_err() {
+                break;
+            }
+            let _ = writer.flush();
+        }
+    });
+
+    // Wait for the child; if the client side closes first, kill it.
+    let mut killer = child.clone_killer();
+    let mut wait_handle =
+        tokio::task::spawn_blocking(move || {
+            let mut child = child;
+            child.wait().map(|s| s.exit_code() as i32).unwrap_or(-1)
+        });
+
+    let code = tokio::select! {
+        res = &mut wait_handle => res.unwrap_or(-1),
+        _ = write_blocking => {
+            // Client went away (Close removed the writer sender). Kill the child.
+            let _ = killer.kill();
+            (&mut wait_handle).await.unwrap_or(-1)
+        }
+    };
+
+    // Child has exited. Drain any remaining output before reporting exit.
+    let _ = read_blocking.await;
+    let _ = forward_task.await;
+
+    // Report exit code, then close the logical connection.
+    for msg in [
+        Message::ExitStatus { conn_id, code },
+        Message::Close { conn_id },
+    ] {
+        if let Ok(bytes) = msg.to_bytes() {
+            if let Ok(encrypted) = crypto.encrypt(&bytes) {
+                let sse_tx = {
+                    let sess = session.lock().await;
+                    sess.sse_tx.clone()
+                };
+                let _ = sse_tx.send(encrypted).await;
+            }
+        }
+    }
+
+    {
+        let mut sess = session.lock().await;
+        sess.tcp_writers.remove(&conn_id);
+        sess.pty_masters.remove(&conn_id);
+    }
+
+    info!("[{}] PTY session closed (exit {})", conn_id, code);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -754,13 +754,13 @@ async fn relay_pty_connection(
     // Child has exited. Give the read task up to 2s to observe EOF on the
     // master (the slave is closed by the child) and finish naturally. If a
     // backgrounded process inherited the slave PTY the slave stays open and
-    // the read would block forever; aborting the read task closes our dup'd
-    // fd, which is safe and immediate (no thread to leak).
+    // the read would block forever; aborting is safe for spawn_blocking (marks
+    // cancelled; the thread finishes once the blocking read returns).
     if tokio::time::timeout(Duration::from_secs(2), &mut read_task).await.is_err() {
         debug!("[{}] PTY read loop still pending (background process holding the pty?)", conn_id);
         read_task.abort();
+        let _ = read_task.await;
     }
-    let _ = read_task.await;
 
     // Drain forward_task so buffered PTY data reaches the client before
     // ExitStatus/Close. read_task dropped pty_out_tx, so forward_task will
@@ -768,8 +768,8 @@ async fn relay_pty_connection(
     if tokio::time::timeout(Duration::from_secs(2), &mut forward_task).await.is_err() {
         debug!("[{}] forward_task still draining after 2s, aborting", conn_id);
         forward_task.abort();
+        let _ = forward_task.await;
     }
-    let _ = forward_task.await;
 
     // Report exit code, then close the logical connection.
     for msg in [

--- a/src/server.rs
+++ b/src/server.rs
@@ -688,9 +688,8 @@ async fn relay_pty_connection(
     };
 
     // forward_task: receive from pty_out_rx, encrypt and push to SSE. Exits
-    // when pty_out_rx returns None (which happens when read_task is dropped
-    // or finishes). Not awaited; it self-cleans on read_task completion.
-    let _forward_task = {
+    // when pty_out_rx returns None (read_task dropped pty_out_tx).
+    let forward_task = {
         let crypto_fwd = crypto.clone();
         let session_fwd = session.clone();
         tokio::spawn(async move {
@@ -787,6 +786,13 @@ async fn relay_pty_connection(
         read_task.abort();
     }
     let _ = read_task.await;
+
+    // Drain forward_task so buffered PTY data reaches the client before
+    // ExitStatus/Close. read_task dropped pty_out_tx, so forward_task will
+    // observe None and exit once it finishes sending queued chunks.
+    if tokio::time::timeout(Duration::from_secs(2), forward_task).await.is_err() {
+        debug!("[{}] forward_task still draining after 2s, proceeding", conn_id);
+    }
 
     // Report exit code, then close the logical connection.
     for msg in [

--- a/src/server.rs
+++ b/src/server.rs
@@ -644,6 +644,9 @@ async fn relay_pty_connection(
             Some(fd) => fd,
             None => {
                 error!("[{}] master PTY has no raw fd", conn_id);
+                let mut sess = session.lock().await;
+                sess.tcp_writers.remove(&conn_id);
+                sess.pty_resize.remove(&conn_id);
                 return;
             }
         };
@@ -651,12 +654,18 @@ async fn relay_pty_connection(
             Ok(fd) => fd,
             Err(e) => {
                 error!("[{}] dup master fd failed: {}", conn_id, e);
+                let mut sess = session.lock().await;
+                sess.tcp_writers.remove(&conn_id);
+                sess.pty_resize.remove(&conn_id);
                 return;
             }
         };
         if let Err(e) = fcntl(dup_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)) {
             error!("[{}] set O_NONBLOCK failed: {}", conn_id, e);
             unsafe { libc::close(dup_fd) };
+            let mut sess = session.lock().await;
+            sess.tcp_writers.remove(&conn_id);
+            sess.pty_resize.remove(&conn_id);
             return;
         }
         let file = unsafe { File::from_raw_fd(dup_fd) };
@@ -664,6 +673,9 @@ async fn relay_pty_connection(
             Ok(afd) => afd,
             Err(e) => {
                 error!("[{}] AsyncFd::new failed: {}", conn_id, e);
+                let mut sess = session.lock().await;
+                sess.tcp_writers.remove(&conn_id);
+                sess.pty_resize.remove(&conn_id);
                 return;
             }
         };
@@ -689,7 +701,7 @@ async fn relay_pty_connection(
 
     // forward_task: receive from pty_out_rx, encrypt and push to SSE. Exits
     // when pty_out_rx returns None (read_task dropped pty_out_tx).
-    let forward_task = {
+    let mut forward_task = {
         let crypto_fwd = crypto.clone();
         let session_fwd = session.clone();
         tokio::spawn(async move {
@@ -790,9 +802,11 @@ async fn relay_pty_connection(
     // Drain forward_task so buffered PTY data reaches the client before
     // ExitStatus/Close. read_task dropped pty_out_tx, so forward_task will
     // observe None and exit once it finishes sending queued chunks.
-    if tokio::time::timeout(Duration::from_secs(2), forward_task).await.is_err() {
-        debug!("[{}] forward_task still draining after 2s, proceeding", conn_id);
+    if tokio::time::timeout(Duration::from_secs(2), &mut forward_task).await.is_err() {
+        debug!("[{}] forward_task still draining after 2s, aborting", conn_id);
+        forward_task.abort();
     }
+    let _ = forward_task.await;
 
     // Report exit code, then close the logical connection.
     for msg in [

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,19 +11,7 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(unix)]
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
-#[cfg(unix)]
-use nix::unistd::dup;
-#[cfg(unix)]
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-#[cfg(unix)]
-use std::fs::File;
-#[cfg(unix)]
-use std::os::fd::FromRawFd;
-#[cfg(unix)]
-use tokio::io::unix::AsyncFd;
-#[cfg(unix)]
-use tokio::io::Interest;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Mutex};
@@ -634,66 +622,32 @@ async fn relay_pty_connection(
     session: Arc<Mutex<Session>>,
     crypto: Arc<Crypto>,
 ) {
-    // PTY -> SSE: dup the master fd, set it non-blocking, and read it through
-    // an AsyncFd. The read task is fully async and cleanly cancellable — no
-    // blocking thread pool involvement, so a stuck background process holding
-    // the slave PTY can be abandoned without leaking an OS thread.
+    // PTY -> SSE: blocking reader on a spawn_blocking thread, bridged to async
+    // via an mpsc channel. Using try_clone_reader() gives us an independent fd
+    // that doesn't share file-status flags with the writer.
     let (pty_out_tx, pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
     let mut read_task = {
-        let raw_fd = match master.as_raw_fd() {
-            Some(fd) => fd,
-            None => {
-                error!("[{}] master PTY has no raw fd", conn_id);
-                let mut sess = session.lock().await;
-                sess.tcp_writers.remove(&conn_id);
-                sess.pty_resize.remove(&conn_id);
-                return;
-            }
-        };
-        let dup_fd = match dup(raw_fd) {
-            Ok(fd) => fd,
+        let mut reader = match master.try_clone_reader() {
+            Ok(r) => r,
             Err(e) => {
-                error!("[{}] dup master fd failed: {}", conn_id, e);
+                error!("[{}] try_clone_reader failed: {}", conn_id, e);
                 let mut sess = session.lock().await;
                 sess.tcp_writers.remove(&conn_id);
                 sess.pty_resize.remove(&conn_id);
                 return;
             }
         };
-        if let Err(e) = fcntl(dup_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)) {
-            error!("[{}] set O_NONBLOCK failed: {}", conn_id, e);
-            let _ = nix::unistd::close(dup_fd);
-            let mut sess = session.lock().await;
-            sess.tcp_writers.remove(&conn_id);
-            sess.pty_resize.remove(&conn_id);
-            return;
-        }
-        let file = unsafe { File::from_raw_fd(dup_fd) };
-        let mut async_fd = match AsyncFd::new(file) {
-            Ok(afd) => afd,
-            Err(e) => {
-                error!("[{}] AsyncFd::new failed: {}", conn_id, e);
-                let mut sess = session.lock().await;
-                sess.tcp_writers.remove(&conn_id);
-                sess.pty_resize.remove(&conn_id);
-                return;
-            }
-        };
-        tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             let mut buf = [0u8; 32768];
             loop {
-                match async_fd.try_io_mut(Interest::READABLE, |file| file.read(&mut buf)) {
-                    Ok(0) => return Ok(()),
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
                     Ok(n) => {
-                        if pty_out_tx.send(buf[..n].to_vec()).await.is_err() {
-                            return Ok(());
+                        if pty_out_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                            break;
                         }
                     }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        async_fd.readable().await?.clear_ready();
-                        continue;
-                    }
-                    Err(e) => return Err(e),
+                    Err(_) => break,
                 }
             }
         })

--- a/src/server.rs
+++ b/src/server.rs
@@ -631,18 +631,21 @@ async fn relay_pty_connection(
             Ok(r) => r,
             Err(e) => {
                 error!("[{}] try_clone_reader failed: {}", conn_id, e);
-                let mut sess = session.lock().await;
+                let sse_tx = {
+                    let mut sess = session.lock().await;
+                    sess.tcp_writers.remove(&conn_id);
+                    sess.pty_resize.remove(&conn_id);
+                    sess.sse_tx.clone()
+                };
                 let msg = Message::Error {
                     conn_id: Some(conn_id),
                     message: format!("try_clone_reader failed: {}", e),
                 };
                 if let Ok(bytes) = msg.to_bytes() {
                     if let Ok(encrypted) = crypto.encrypt(&bytes) {
-                        let _ = sess.sse_tx.send(encrypted).await;
+                        let _ = sse_tx.send(encrypted).await;
                     }
                 }
-                sess.tcp_writers.remove(&conn_id);
-                sess.pty_resize.remove(&conn_id);
                 return;
             }
         };

--- a/src/server.rs
+++ b/src/server.rs
@@ -383,7 +383,7 @@ async fn handle_send(
             ok_response("")
         }
         #[cfg(unix)]
-        Message::Exec { conn_id, cmd, cols, rows } => {
+        Message::Exec { conn_id, cmd, cols, rows, term } => {
             if !hot.allow_exec {
                 warn!("[{}] EXEC denied: remote exec disabled", conn_id);
                 return encrypted_response(
@@ -424,7 +424,7 @@ async fn handle_send(
                     CommandBuilder::new(if shell.is_empty() { "/bin/sh".to_string() } else { shell })
                 }
             };
-            builder.env("TERM", "xterm-256color");
+            builder.env("TERM", if term.is_empty() { "xterm-256color".to_string() } else { term });
 
             let child = match pair.slave.spawn_command(builder) {
                 Ok(c) => c,

--- a/src/server.rs
+++ b/src/server.rs
@@ -637,13 +637,25 @@ async fn relay_pty_connection(
                 Ok(e) => e,
                 Err(e) => { error!("[{}] PTY encrypt: {}", conn_id, e); break; }
             };
-            let sse_tx = {
-                let sess = session_fwd.lock().await;
-                sess.sse_tx.clone()
-            };
-            if sse_tx.send(encrypted).await.is_err() {
-                debug!("[{}] SSE stream replaced or closed", conn_id);
+            // Retry across a client reconnect (the SSE channel is dropped and
+            // replaced) so PTY output isn't silently lost. Re-fetch sse_tx each
+            // attempt to pick up the new channel; give up after ~5s.
+            let mut sent = false;
+            for _ in 0..50 {
+                let sse_tx = {
+                    let sess = session_fwd.lock().await;
+                    sess.sse_tx.clone()
+                };
+                if sse_tx.send(encrypted.clone()).await.is_ok() {
+                    sent = true;
+                    break;
+                }
+                debug!("[{}] SSE stream replaced or closed; retrying", conn_id);
                 tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            if !sent {
+                error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
+                break;
             }
         }
     });

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,19 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(unix)]
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
+#[cfg(unix)]
+use nix::unistd::dup;
+#[cfg(unix)]
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use tokio::io::unix::AsyncFd;
+#[cfg(unix)]
+use tokio::io::Interest;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Mutex};
@@ -29,9 +41,11 @@ struct Session {
     /// Per-conn_id sink for client→target bytes. Covers both TCP connections and
     /// PTYs (remote exec) — a PTY is just another duplex byte stream.
     tcp_writers: HashMap<u32, mpsc::Sender<Vec<u8>>>,
-    /// PTY masters kept alive per conn_id so we can apply terminal resizes.
+    /// Per-conn_id resize request channel for remote-exec PTYs. Senders are
+    /// kept in the session so Message::Resize can deliver a new PtySize
+    /// without taking the master PTY out of `relay_pty_connection`.
     #[cfg(unix)]
-    pty_masters: HashMap<u32, Box<dyn MasterPty + Send>>,
+    pty_resize: HashMap<u32, mpsc::Sender<PtySize>>,
     /// SSE channel: encrypted messages queued for streaming to client
     sse_tx: mpsc::Sender<Vec<u8>>,
 }
@@ -200,7 +214,7 @@ async fn handle_stream(session_id: &str, state: &ServerState) -> Response<BoxBod
                 Arc::new(Mutex::new(Session {
                     tcp_writers: HashMap::new(),
                     #[cfg(unix)]
-                    pty_masters: HashMap::new(),
+                    pty_resize: HashMap::new(),
                     sse_tx: sse_tx.clone(),
                 }))
             })
@@ -432,17 +446,8 @@ async fn handle_send(
             // Drop the slave handle so the master reader sees EOF once the child exits.
             drop(pair.slave);
 
-            let reader = match pair.master.try_clone_reader() {
-                Ok(r) => r,
-                Err(e) => {
-                    error!("[{}] clone reader failed: {}", conn_id, e);
-                    return encrypted_response(
-                        &hot.crypto,
-                        &Message::Error { conn_id: Some(conn_id), message: format!("pty reader failed: {}", e) },
-                    );
-                }
-            };
-            let writer = match pair.master.take_writer() {
+            let master = pair.master;
+            let writer = match master.take_writer() {
                 Ok(w) => w,
                 Err(e) => {
                     error!("[{}] take writer failed: {}", conn_id, e);
@@ -454,15 +459,16 @@ async fn handle_send(
             };
 
             let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(256);
+            let (resize_tx, resize_rx) = mpsc::channel::<PtySize>(4);
             {
                 let mut sess = session.lock().await;
                 sess.tcp_writers.insert(conn_id, write_tx);
-                sess.pty_masters.insert(conn_id, pair.master);
+                sess.pty_resize.insert(conn_id, resize_tx);
             }
 
             let crypto = hot.crypto.clone();
             tokio::spawn(async move {
-                relay_pty_connection(conn_id, reader, writer, child, write_rx, session, crypto).await;
+                relay_pty_connection(conn_id, master, writer, child, write_rx, resize_rx, session, crypto).await;
             });
 
             encrypted_response(&hot.crypto, &Message::Data { conn_id, data: vec![] })
@@ -482,8 +488,8 @@ async fn handle_send(
         Message::Resize { conn_id, cols, rows } => {
             debug!("[{}] RESIZE {}x{}", conn_id, cols, rows);
             let sess = session.lock().await;
-            if let Some(master) = sess.pty_masters.get(&conn_id) {
-                let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+            if let Some(tx) = sess.pty_resize.get(&conn_id) {
+                let _ = tx.try_send(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
             }
             ok_response("")
         }
@@ -620,67 +626,82 @@ async fn relay_tcp_connection(
 #[cfg(unix)]
 async fn relay_pty_connection(
     conn_id: u32,
-    reader: Box<dyn Read + Send>,
+    master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
     write_rx: mpsc::Receiver<Vec<u8>>,
+    resize_rx: mpsc::Receiver<PtySize>,
     session: Arc<Mutex<Session>>,
     crypto: Arc<Crypto>,
 ) {
-    // PTY -> SSE: blocking reader feeds a channel; an async task encrypts and
-    // forwards to the (possibly-reconnected) SSE sender.
+    // PTY -> SSE: dup the master fd, set it non-blocking, and read it through
+    // an AsyncFd. The read task is fully async and cleanly cancellable — no
+    // blocking thread pool involvement, so a stuck background process holding
+    // the slave PTY can be abandoned without leaking an OS thread.
     let (pty_out_tx, pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
-    let read_blocking = tokio::task::spawn_blocking(move || {
-        let mut reader = reader;
-        let mut buf = vec![0u8; 32768];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    if pty_out_tx.blocking_send(buf[..n].to_vec()).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
+    let mut read_task = {
+        let raw_fd = match master.as_raw_fd() {
+            Some(fd) => fd,
+            None => {
+                error!("[{}] master PTY has no raw fd", conn_id);
+                return;
             }
+        };
+        let dup_fd = match dup(raw_fd) {
+            Ok(fd) => fd,
+            Err(e) => {
+                error!("[{}] dup master fd failed: {}", conn_id, e);
+                return;
+            }
+        };
+        if let Err(e) = fcntl(dup_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)) {
+            error!("[{}] set O_NONBLOCK failed: {}", conn_id, e);
+            unsafe { libc::close(dup_fd) };
+            return;
         }
-    });
-
-    // Signal sent to the forward task on child exit so it can do a final
-    // best-effort flush of whatever is currently in the channel and exit,
-    // rather than waiting indefinitely for `pty_out_rx` to close (it never
-    // does if a backgrounded process inherited the slave PTY).
-    let drain_signal = Arc::new(tokio::sync::Notify::new());
-    let drain_signal_fwd = drain_signal.clone();
-    let crypto_fwd = crypto.clone();
-    let session_fwd = session.clone();
-    let forward_task = tokio::spawn(async move {
-        let mut pty_out_rx = pty_out_rx;
-        loop {
-            tokio::select! {
-                biased;
-                _ = drain_signal_fwd.notified() => {
-                    // Drain whatever is currently buffered and exit. The
-                    // outer timeouts bound how long this can take.
-                    while let Ok(data) = pty_out_rx.try_recv() {
-                        if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
-                            return;
+        let file = unsafe { File::from_raw_fd(dup_fd) };
+        let mut async_fd = match AsyncFd::new(file) {
+            Ok(afd) => afd,
+            Err(e) => {
+                error!("[{}] AsyncFd::new failed: {}", conn_id, e);
+                return;
+            }
+        };
+        tokio::spawn(async move {
+            let mut buf = [0u8; 32768];
+            loop {
+                match async_fd.try_io_mut(Interest::READABLE, |file| file.read(&mut buf)) {
+                    Ok(0) => return Ok(()),
+                    Ok(n) => {
+                        if pty_out_tx.send(buf[..n].to_vec()).await.is_err() {
+                            return Ok(());
                         }
                     }
-                    return;
-                }
-                data = pty_out_rx.recv() => {
-                    let Some(data) = data else { return };
-                    if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
-                        return;
-                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) => return Err(e),
                 }
             }
-        }
-    });
+        })
+    };
+
+    // forward_task: receive from pty_out_rx, encrypt and push to SSE. Exits
+    // when pty_out_rx returns None (which happens when read_task is dropped
+    // or finishes). Not awaited; it self-cleans on read_task completion.
+    let _forward_task = {
+        let crypto_fwd = crypto.clone();
+        let session_fwd = session.clone();
+        tokio::spawn(async move {
+            let mut pty_out_rx = pty_out_rx;
+            while let Some(data) = pty_out_rx.recv().await {
+                if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
+                    return;
+                }
+            }
+        })
+    };
 
     // client -> PTY: blocking writer fed by the per-conn write channel.
-    let write_blocking = tokio::task::spawn_blocking(move || {
+    let mut write_blocking = tokio::task::spawn_blocking(move || {
         let mut writer = writer;
         let mut write_rx = write_rx;
         while let Some(data) = write_rx.blocking_recv() {
@@ -704,48 +725,65 @@ async fn relay_pty_connection(
 
     // Watchdog: an abrupt client disconnect (network drop, process killed)
     // leaves write_tx in tcp_writers, so write_blocking never finishes and the
-    // child runs forever. Periodically probe the session's sse_tx; once the
-    // SSE receiver is gone, kill the child and join.
+    // child runs forever. Probe the session's sse_tx; only kill the child if
+    // SSE has been continuously closed for at least 6s, so transient drops
+    // (e.g., a client reconnect within forward_pty_chunk's 5s retry window)
+    // don't kill an otherwise-healthy session.
     let session_watch = session.clone();
     let sse_dead = async move {
+        let mut closed_secs: u32 = 0;
         loop {
-            tokio::time::sleep(Duration::from_secs(2)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             let sess = session_watch.lock().await;
             if sess.sse_tx.is_closed() {
-                return;
+                closed_secs += 1;
+                if closed_secs >= 6 {
+                    return;
+                }
+            } else {
+                closed_secs = 0;
             }
         }
     };
+    // Box::pin so we can re-poll across loop iterations; the async block
+    // holds a !Unpin MutexGuard across .await.
+    let mut sse_dead = Box::pin(sse_dead);
 
-    let code = tokio::select! {
-        res = &mut wait_handle => res.unwrap_or(-1),
-        _ = write_blocking => {
-            // Client went away (Close removed the writer sender). Kill the child.
-            let _ = killer.kill();
-            (&mut wait_handle).await.unwrap_or(-1)
-        }
-        _ = sse_dead => {
-            debug!("[{}] SSE stream closed; killing orphaned PTY child", conn_id);
-            let _ = killer.kill();
-            (&mut wait_handle).await.unwrap_or(-1)
+    let mut resize_rx = resize_rx;
+    let code = loop {
+        tokio::select! {
+            res = &mut wait_handle => break res.unwrap_or(-1),
+            _ = &mut write_blocking => {
+                // Client went away (Close removed the writer sender). Kill the child.
+                let _ = killer.kill();
+                break (&mut wait_handle).await.unwrap_or(-1);
+            }
+            _ = &mut sse_dead => {
+                debug!("[{}] SSE stream closed continuously; killing orphaned PTY child", conn_id);
+                let _ = killer.kill();
+                break (&mut wait_handle).await.unwrap_or(-1);
+            }
+            new_size = resize_rx.recv() => {
+                if let Some(s) = new_size {
+                    if let Err(e) = master.resize(s) {
+                        error!("[{}] PTY resize failed: {}", conn_id, e);
+                    }
+                }
+            }
         }
     };
+    drop(master);
 
-    // Child has exited. Signal the forward task to flush whatever is in the
-    // channel, then wait briefly for the read_blocking thread to finish.
-    // Bound the wait: if a backgrounded process inherited the slave PTY, the
-    // master never sees EOF and the blocking reader would otherwise hang
-    // forever. In that case we abandon forward_task; any output still sitting
-    // in the channel when the master reader finally closes will be lost
-    // (forward_task is the only consumer).
-    drain_signal.notify_one();
-    let drain = async {
-        let _ = forward_task.await;
-        let _ = read_blocking.await;
-    };
-    if tokio::time::timeout(Duration::from_secs(2), drain).await.is_err() {
-        debug!("[{}] PTY output drain timed out (background process holding the pty?)", conn_id);
+    // Child has exited. Give the read task up to 2s to observe EOF on the
+    // master (the slave is closed by the child) and finish naturally. If a
+    // backgrounded process inherited the slave PTY the slave stays open and
+    // the read would block forever; aborting the read task closes our dup'd
+    // fd, which is safe and immediate (no thread to leak).
+    if tokio::time::timeout(Duration::from_secs(2), &mut read_task).await.is_err() {
+        debug!("[{}] PTY read loop still pending (background process holding the pty?)", conn_id);
+        read_task.abort();
     }
+    let _ = read_task.await;
 
     // Report exit code, then close the logical connection.
     for msg in [
@@ -767,7 +805,7 @@ async fn relay_pty_connection(
         let mut sess = session.lock().await;
         sess.tcp_writers.remove(&conn_id);
         #[cfg(unix)]
-        sess.pty_masters.remove(&conn_id);
+        sess.pty_resize.remove(&conn_id);
     }
 
     info!("[{}] PTY session closed (exit {})", conn_id, code);

--- a/src/server.rs
+++ b/src/server.rs
@@ -632,6 +632,15 @@ async fn relay_pty_connection(
             Err(e) => {
                 error!("[{}] try_clone_reader failed: {}", conn_id, e);
                 let mut sess = session.lock().await;
+                let msg = Message::Error {
+                    conn_id: Some(conn_id),
+                    message: format!("try_clone_reader failed: {}", e),
+                };
+                if let Ok(bytes) = msg.to_bytes() {
+                    if let Ok(encrypted) = crypto.encrypt(&bytes) {
+                        let _ = sess.sse_tx.send(encrypted).await;
+                    }
+                }
                 sess.tcp_writers.remove(&conn_id);
                 sess.pty_resize.remove(&conn_id);
                 return;

--- a/src/server.rs
+++ b/src/server.rs
@@ -677,7 +677,10 @@ async fn relay_pty_connection(
                             return Ok(());
                         }
                     }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        async_fd.readable().await?.clear_ready();
+                        continue;
+                    }
                     Err(e) => return Err(e),
                 }
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -683,10 +683,30 @@ async fn relay_pty_connection(
             child.wait().map(|s| s.exit_code() as i32).unwrap_or(-1)
         });
 
+    // Watchdog: an abrupt client disconnect (network drop, process killed)
+    // leaves write_tx in tcp_writers, so write_blocking never finishes and the
+    // child runs forever. Periodically probe the session's sse_tx; once the
+    // SSE receiver is gone, kill the child and join.
+    let session_watch = session.clone();
+    let sse_dead = async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let sess = session_watch.lock().await;
+            if sess.sse_tx.is_closed() {
+                return;
+            }
+        }
+    };
+
     let code = tokio::select! {
         res = &mut wait_handle => res.unwrap_or(-1),
         _ = write_blocking => {
             // Client went away (Close removed the writer sender). Kill the child.
+            let _ = killer.kill();
+            (&mut wait_handle).await.unwrap_or(-1)
+        }
+        _ = sse_dead => {
+            debug!("[{}] SSE stream closed; killing orphaned PTY child", conn_id);
             let _ = killer.kill();
             (&mut wait_handle).await.unwrap_or(-1)
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(unix)]
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -29,6 +30,7 @@ struct Session {
     /// PTYs (remote exec) — a PTY is just another duplex byte stream.
     tcp_writers: HashMap<u32, mpsc::Sender<Vec<u8>>>,
     /// PTY masters kept alive per conn_id so we can apply terminal resizes.
+    #[cfg(unix)]
     pty_masters: HashMap<u32, Box<dyn MasterPty + Send>>,
     /// SSE channel: encrypted messages queued for streaming to client
     sse_tx: mpsc::Sender<Vec<u8>>,
@@ -197,6 +199,7 @@ async fn handle_stream(session_id: &str, state: &ServerState) -> Response<BoxBod
             .or_insert_with(|| {
                 Arc::new(Mutex::new(Session {
                     tcp_writers: HashMap::new(),
+                    #[cfg(unix)]
                     pty_masters: HashMap::new(),
                     sse_tx: sse_tx.clone(),
                 }))
@@ -377,6 +380,7 @@ async fn handle_send(
             sess.tcp_writers.remove(&conn_id);
             ok_response("")
         }
+        #[cfg(unix)]
         Message::Exec { conn_id, cmd, cols, rows } => {
             if !hot.allow_exec {
                 warn!("[{}] EXEC denied: remote exec disabled", conn_id);
@@ -463,12 +467,29 @@ async fn handle_send(
 
             encrypted_response(&hot.crypto, &Message::Data { conn_id, data: vec![] })
         }
+        #[cfg(not(unix))]
+        Message::Exec { conn_id, .. } => {
+            warn!("[{}] EXEC denied: remote exec is not supported on this platform", conn_id);
+            encrypted_response(
+                &hot.crypto,
+                &Message::Error {
+                    conn_id: Some(conn_id),
+                    message: "remote exec is not supported on this platform".to_string(),
+                },
+            )
+        }
+        #[cfg(unix)]
         Message::Resize { conn_id, cols, rows } => {
             debug!("[{}] RESIZE {}x{}", conn_id, cols, rows);
             let sess = session.lock().await;
             if let Some(master) = sess.pty_masters.get(&conn_id) {
                 let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
             }
+            ok_response("")
+        }
+        #[cfg(not(unix))]
+        Message::Resize { conn_id, .. } => {
+            debug!("[{}] RESIZE ignored: remote exec is not supported on this platform", conn_id);
             ok_response("")
         }
         Message::Ping => {
@@ -596,6 +617,7 @@ async fn relay_tcp_connection(
 /// PTY readers/writers are blocking std::io, so the blocking halves run on
 /// `spawn_blocking` threads and bridge to async via channels — but the SSE send
 /// path mirrors `relay_tcp_connection` so it stays reconnection-aware.
+#[cfg(unix)]
 async fn relay_pty_connection(
     conn_id: u32,
     reader: Box<dyn Read + Send>,
@@ -607,7 +629,7 @@ async fn relay_pty_connection(
 ) {
     // PTY -> SSE: blocking reader feeds a channel; an async task encrypts and
     // forwards to the (possibly-reconnected) SSE sender.
-    let (pty_out_tx, mut pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
+    let (pty_out_tx, pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
     let read_blocking = tokio::task::spawn_blocking(move || {
         let mut reader = reader;
         let mut buf = vec![0u8; 32768];
@@ -624,38 +646,35 @@ async fn relay_pty_connection(
         }
     });
 
+    // Signal sent to the forward task on child exit so it can do a final
+    // best-effort flush of whatever is currently in the channel and exit,
+    // rather than waiting indefinitely for `pty_out_rx` to close (it never
+    // does if a backgrounded process inherited the slave PTY).
+    let drain_signal = Arc::new(tokio::sync::Notify::new());
+    let drain_signal_fwd = drain_signal.clone();
     let crypto_fwd = crypto.clone();
     let session_fwd = session.clone();
     let forward_task = tokio::spawn(async move {
-        while let Some(data) = pty_out_rx.recv().await {
-            let msg = Message::Data { conn_id, data };
-            let bytes = match msg.to_bytes() {
-                Ok(b) => b,
-                Err(e) => { error!("[{}] PTY serialize: {}", conn_id, e); break; }
-            };
-            let encrypted = match crypto_fwd.encrypt(&bytes) {
-                Ok(e) => e,
-                Err(e) => { error!("[{}] PTY encrypt: {}", conn_id, e); break; }
-            };
-            // Retry across a client reconnect (the SSE channel is dropped and
-            // replaced) so PTY output isn't silently lost. Re-fetch sse_tx each
-            // attempt to pick up the new channel; give up after ~5s.
-            let mut sent = false;
-            for _ in 0..50 {
-                let sse_tx = {
-                    let sess = session_fwd.lock().await;
-                    sess.sse_tx.clone()
-                };
-                if sse_tx.send(encrypted.clone()).await.is_ok() {
-                    sent = true;
-                    break;
+        let mut pty_out_rx = pty_out_rx;
+        loop {
+            tokio::select! {
+                biased;
+                _ = drain_signal_fwd.notified() => {
+                    // Drain whatever is currently buffered and exit. The
+                    // outer timeouts bound how long this can take.
+                    while let Ok(data) = pty_out_rx.try_recv() {
+                        if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
+                            return;
+                        }
+                    }
+                    return;
                 }
-                debug!("[{}] SSE stream replaced or closed; retrying", conn_id);
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-            if !sent {
-                error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
-                break;
+                data = pty_out_rx.recv() => {
+                    let Some(data) = data else { return };
+                    if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
+                        return;
+                    }
+                }
             }
         }
     });
@@ -712,12 +731,17 @@ async fn relay_pty_connection(
         }
     };
 
-    // Child has exited. Drain any remaining output before reporting exit, but
-    // bound the wait: if a backgrounded process inherited the slave PTY, the
-    // master never sees EOF and the blocking reader would otherwise hang forever.
+    // Child has exited. Signal the forward task to flush whatever is in the
+    // channel, then wait briefly for the read_blocking thread to finish.
+    // Bound the wait: if a backgrounded process inherited the slave PTY, the
+    // master never sees EOF and the blocking reader would otherwise hang
+    // forever. In that case we abandon forward_task; any output still sitting
+    // in the channel when the master reader finally closes will be lost
+    // (forward_task is the only consumer).
+    drain_signal.notify_one();
     let drain = async {
-        let _ = read_blocking.await;
         let _ = forward_task.await;
+        let _ = read_blocking.await;
     };
     if tokio::time::timeout(Duration::from_secs(2), drain).await.is_err() {
         debug!("[{}] PTY output drain timed out (background process holding the pty?)", conn_id);
@@ -742,8 +766,43 @@ async fn relay_pty_connection(
     {
         let mut sess = session.lock().await;
         sess.tcp_writers.remove(&conn_id);
+        #[cfg(unix)]
         sess.pty_masters.remove(&conn_id);
     }
 
     info!("[{}] PTY session closed (exit {})", conn_id, code);
+}
+
+/// Encrypt one PTY chunk and push it to the (possibly-reconnected) SSE sender.
+/// Retries briefly across a client reconnect so a transient SSE drop doesn't
+/// lose output. Returns false if the chunk could not be delivered.
+#[cfg(unix)]
+async fn forward_pty_chunk(
+    conn_id: u32,
+    data: Vec<u8>,
+    crypto: &Crypto,
+    session: &Arc<Mutex<Session>>,
+) -> bool {
+    let msg = Message::Data { conn_id, data };
+    let bytes = match msg.to_bytes() {
+        Ok(b) => b,
+        Err(e) => { error!("[{}] PTY serialize: {}", conn_id, e); return false; }
+    };
+    let encrypted = match crypto.encrypt(&bytes) {
+        Ok(e) => e,
+        Err(e) => { error!("[{}] PTY encrypt: {}", conn_id, e); return false; }
+    };
+    for _ in 0..50 {
+        let sse_tx = {
+            let sess = session.lock().await;
+            sess.sse_tx.clone()
+        };
+        if sse_tx.send(encrypted.clone()).await.is_ok() {
+            return true;
+        }
+        debug!("[{}] SSE stream replaced or closed; retrying", conn_id);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
+    false
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -662,7 +662,7 @@ async fn relay_pty_connection(
         };
         if let Err(e) = fcntl(dup_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)) {
             error!("[{}] set O_NONBLOCK failed: {}", conn_id, e);
-            unsafe { libc::close(dup_fd) };
+            let _ = nix::unistd::close(dup_fd);
             let mut sess = session.lock().await;
             sess.tcp_writers.remove(&conn_id);
             sess.pty_resize.remove(&conn_id);
@@ -815,11 +815,21 @@ async fn relay_pty_connection(
     ] {
         if let Ok(bytes) = msg.to_bytes() {
             if let Ok(encrypted) = crypto.encrypt(&bytes) {
-                let sse_tx = {
-                    let sess = session.lock().await;
-                    sess.sse_tx.clone()
-                };
-                let _ = sse_tx.send(encrypted).await;
+                let mut sent = false;
+                for _ in 0..50 {
+                    let sse_tx = {
+                        let sess = session.lock().await;
+                        sess.sse_tx.clone()
+                    };
+                    if sse_tx.send(encrypted.clone()).await.is_ok() {
+                        sent = true;
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                if !sent {
+                    error!("[{}] failed to deliver shutdown message", conn_id);
+                }
             }
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -796,9 +796,9 @@ async fn relay_pty_connection(
             }
         }
     };
-    // Box::pin so we can re-poll across loop iterations; the async block
-    // holds a !Unpin MutexGuard across .await.
-    let mut sse_dead = Box::pin(sse_dead);
+    // Pin to the stack so we can re-poll across loop iterations; the async
+    // block holds a !Unpin MutexGuard across .await.
+    tokio::pin!(sse_dead);
 
     let mut resize_rx = resize_rx;
     let code = loop {

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(unix)]
@@ -417,7 +417,12 @@ async fn handle_send(
                     b.arg(c);
                     b
                 }
-                None => CommandBuilder::new(std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())),
+                None => {
+                    // Fall back to /bin/sh when SHELL is unset OR set-but-empty;
+                    // an empty program name would make the spawn fail with ENOENT.
+                    let shell = std::env::var("SHELL").unwrap_or_default();
+                    CommandBuilder::new(if shell.is_empty() { "/bin/sh".to_string() } else { shell })
+                }
             };
             builder.env("TERM", "xterm-256color");
 
@@ -622,78 +627,144 @@ async fn relay_pty_connection(
     session: Arc<Mutex<Session>>,
     crypto: Arc<Crypto>,
 ) {
-    // PTY -> SSE: blocking reader on a spawn_blocking thread, bridged to async
-    // via an mpsc channel. Using try_clone_reader() gives us an independent fd
-    // that doesn't share file-status flags with the writer.
-    let (pty_out_tx, pty_out_rx) = mpsc::channel::<Vec<u8>>(64);
-    let mut read_task = {
-        let mut reader = match master.try_clone_reader() {
-            Ok(r) => r,
-            Err(e) => {
-                error!("[{}] try_clone_reader failed: {}", conn_id, e);
-                let sse_tx = {
-                    let mut sess = session.lock().await;
-                    sess.tcp_writers.remove(&conn_id);
-                    sess.pty_resize.remove(&conn_id);
-                    sess.sse_tx.clone()
-                };
-                let msg = Message::Error {
-                    conn_id: Some(conn_id),
-                    message: format!("try_clone_reader failed: {}", e),
-                };
-                if let Ok(bytes) = msg.to_bytes() {
-                    if let Ok(encrypted) = crypto.encrypt(&bytes) {
-                        let _ = sse_tx.send(encrypted).await;
-                    }
-                }
-                return;
+    // PTY <-> SSE. The master fd is driven with non-blocking I/O via tokio's
+    // AsyncFd so both directions live on the async runtime, with no
+    // spawn_blocking threads. This matters on teardown: a backgrounded process
+    // can keep the slave open so the master never reaches EOF, and a blocking
+    // reader thread parked in read() cannot be cancelled (abort() only marks
+    // the JoinHandle; the OS thread lives on). An AsyncFd read task aborts
+    // cleanly instead of leaking a thread for that background process's life.
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use tokio::io::unix::AsyncFd;
+    use tokio::io::Interest;
+
+    // try_clone_reader()/take_writer() both dup() the master fd, so they all
+    // share one open file description — and therefore the O_NONBLOCK flag. We
+    // set it once on the master and hand each task its own dup'd AsyncFd.
+    let setup = (|| -> std::io::Result<(AsyncFd<OwnedFd>, AsyncFd<OwnedFd>)> {
+        let master_fd = master
+            .as_raw_fd()
+            .ok_or_else(|| std::io::Error::other("PTY master has no fd"))?;
+        unsafe {
+            let flags = libc::fcntl(master_fd, libc::F_GETFL);
+            if flags < 0 {
+                return Err(std::io::Error::last_os_error());
             }
+            if libc::fcntl(master_fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+        let dup_afd = |interest| -> std::io::Result<AsyncFd<OwnedFd>> {
+            let fd = unsafe { libc::dup(master_fd) };
+            if fd < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            AsyncFd::with_interest(unsafe { OwnedFd::from_raw_fd(fd) }, interest)
         };
-        tokio::task::spawn_blocking(move || {
-            let mut buf = [0u8; 32768];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if pty_out_tx.blocking_send(buf[..n].to_vec()).is_err() {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
+        Ok((dup_afd(Interest::READABLE)?, dup_afd(Interest::WRITABLE)?))
+    })();
+    let (read_afd, write_afd) = match setup {
+        Ok(pair) => pair,
+        Err(e) => {
+            error!("[{}] PTY async setup failed: {}", conn_id, e);
+            let sse_tx = {
+                let mut sess = session.lock().await;
+                sess.tcp_writers.remove(&conn_id);
+                sess.pty_resize.remove(&conn_id);
+                sess.sse_tx.clone()
+            };
+            let msg = Message::Error {
+                conn_id: Some(conn_id),
+                message: format!("PTY setup failed: {}", e),
+            };
+            if let Ok(bytes) = msg.to_bytes() {
+                if let Ok(encrypted) = crypto.encrypt(&bytes) {
+                    let _ = sse_tx.send(encrypted).await;
                 }
             }
-        })
+            return;
+        }
     };
 
-    // forward_task: receive from pty_out_rx, encrypt and push to SSE. Exits
-    // when pty_out_rx returns None (read_task dropped pty_out_tx).
-    let mut forward_task = {
+    // PTY -> SSE: read on the runtime, then encrypt and forward each chunk.
+    let mut read_task = {
         let crypto_fwd = crypto.clone();
         let session_fwd = session.clone();
         tokio::spawn(async move {
-            let mut pty_out_rx = pty_out_rx;
-            while let Some(data) = pty_out_rx.recv().await {
-                if !forward_pty_chunk(conn_id, data, &crypto_fwd, &session_fwd).await {
-                    return;
+            let mut buf = [0u8; 32768];
+            loop {
+                let mut guard = match read_afd.readable().await {
+                    Ok(g) => g,
+                    Err(_) => break,
+                };
+                match guard.try_io(|inner| {
+                    let n = unsafe {
+                        libc::read(
+                            inner.get_ref().as_raw_fd(),
+                            buf.as_mut_ptr() as *mut libc::c_void,
+                            buf.len(),
+                        )
+                    };
+                    if n < 0 {
+                        Err(std::io::Error::last_os_error())
+                    } else {
+                        Ok(n as usize)
+                    }
+                }) {
+                    Ok(Ok(0)) => break, // EOF: slave fully closed
+                    Ok(Ok(n)) => {
+                        if !forward_pty_chunk(conn_id, buf[..n].to_vec(), &crypto_fwd, &session_fwd).await {
+                            break;
+                        }
+                    }
+                    Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Ok(Err(_)) => break,           // read error
+                    Err(_would_block) => continue, // readiness was spurious
                 }
             }
         })
     };
 
-    // client -> PTY: blocking writer fed by the per-conn write channel.
-    let mut write_blocking = tokio::task::spawn_blocking(move || {
-        let mut writer = writer;
-        let mut write_rx = write_rx;
-        while let Some(data) = write_rx.blocking_recv() {
-            if data.is_empty() {
-                continue;
+    // client -> PTY: drain the per-conn write channel onto the master. `writer`
+    // is moved in only so its Drop sends EOF to the shell at teardown (parity
+    // with the previous blocking writer); the bytes themselves go via write_afd.
+    let mut write_task = {
+        tokio::spawn(async move {
+            let _writer = writer;
+            let mut write_rx = write_rx;
+            while let Some(data) = write_rx.recv().await {
+                if data.is_empty() {
+                    continue;
+                }
+                let mut pos = 0;
+                while pos < data.len() {
+                    let mut guard = match write_afd.writable().await {
+                        Ok(g) => g,
+                        Err(_) => return,
+                    };
+                    match guard.try_io(|inner| {
+                        let n = unsafe {
+                            libc::write(
+                                inner.get_ref().as_raw_fd(),
+                                data[pos..].as_ptr() as *const libc::c_void,
+                                data.len() - pos,
+                            )
+                        };
+                        if n < 0 {
+                            Err(std::io::Error::last_os_error())
+                        } else {
+                            Ok(n as usize)
+                        }
+                    }) {
+                        Ok(Ok(n)) => pos += n,
+                        Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Ok(Err(_)) => return,
+                        Err(_would_block) => continue,
+                    }
+                }
             }
-            if writer.write_all(&data).is_err() {
-                break;
-            }
-            let _ = writer.flush();
-        }
-    });
+        })
+    };
 
     // Wait for the child; if the client side closes first, kill it.
     let mut killer = child.clone_killer();
@@ -733,7 +804,7 @@ async fn relay_pty_connection(
     let code = loop {
         tokio::select! {
             res = &mut wait_handle => break res.unwrap_or(-1),
-            _ = &mut write_blocking => {
+            _ = &mut write_task => {
                 // Client went away (Close removed the writer sender). Kill the child.
                 let _ = killer.kill();
                 break (&mut wait_handle).await.unwrap_or(-1);
@@ -754,25 +825,22 @@ async fn relay_pty_connection(
     };
     drop(master);
 
-    // Child has exited. Give the read task up to 2s to observe EOF on the
-    // master (the slave is closed by the child) and finish naturally. If a
-    // backgrounded process inherited the slave PTY the slave stays open and
-    // the read would block forever; aborting is safe for spawn_blocking (marks
-    // cancelled; the thread finishes once the blocking read returns).
+    // Child has exited. Give the read task up to 2s to drain buffered PTY
+    // output and observe EOF, then abort. With AsyncFd the read task is a plain
+    // async task: if a backgrounded process keeps the slave open so EOF never
+    // arrives, abort() cancels it immediately — no blocking thread is left
+    // parked in read() as the old spawn_blocking reader would have been.
     if tokio::time::timeout(Duration::from_secs(2), &mut read_task).await.is_err() {
-        debug!("[{}] PTY read loop still pending (background process holding the pty?)", conn_id);
+        debug!("[{}] PTY read loop still pending (background process holding the pty?); aborting", conn_id);
         read_task.abort();
         let _ = read_task.await;
     }
 
-    // Drain forward_task so buffered PTY data reaches the client before
-    // ExitStatus/Close. read_task dropped pty_out_tx, so forward_task will
-    // observe None and exit once it finishes sending queued chunks.
-    if tokio::time::timeout(Duration::from_secs(2), &mut forward_task).await.is_err() {
-        debug!("[{}] forward_task still draining after 2s, aborting", conn_id);
-        forward_task.abort();
-        let _ = forward_task.await;
-    }
+    // The write task ends on its own once the client closes the write channel;
+    // abort it in case we're tearing down while it's parked waiting for the
+    // master to become writable.
+    write_task.abort();
+    let _ = write_task.await;
 
     // Report exit code, then close the logical connection.
     for msg in [

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -375,3 +375,109 @@ impl Tunnel {
         channels.remove(&conn_id);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a Tunnel without a live server. handle_sse_message only touches
+    /// `hot.crypto` (to decrypt) and `response_channels` (to dispatch), so the
+    /// http_client / server_base_url are placeholders.
+    fn test_tunnel(password: &str) -> Tunnel {
+        let hot = HotClientConfig {
+            crypto: Arc::new(Crypto::new(password).unwrap()),
+            http_client: reqwest::Client::new(),
+            server_base_url: "http://127.0.0.1:0".to_string(),
+        };
+        Tunnel {
+            session_id: Arc::new(tokio::sync::RwLock::new("test-session".to_string())),
+            hot: Arc::new(ArcSwap::from_pointee(hot)),
+            response_channels: Arc::new(Mutex::new(HashMap::new())),
+            reconnect_signal: Arc::new(Notify::new()),
+            sse_ready: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Encrypt a message the way the server would before pushing it over SSE.
+    fn sse_frame(tunnel: &Tunnel, msg: &Message) -> Vec<u8> {
+        let bytes = msg.to_bytes().unwrap();
+        tunnel.hot.load().crypto.encrypt(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn data_is_dispatched_to_the_registered_conn() {
+        let tunnel = test_tunnel("pw");
+        let mut rx = tunnel.register_connection(1).await;
+
+        let frame = sse_frame(&tunnel, &Message::Data { conn_id: 1, data: b"hello".to_vec() });
+        tunnel.handle_sse_message(&frame).await;
+
+        match rx.try_recv() {
+            Ok(TunnelEvent::Data(d)) => assert_eq!(d, b"hello"),
+            other => panic!("expected Data event, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn close_delivers_a_close_event() {
+        let tunnel = test_tunnel("pw");
+        let mut rx = tunnel.register_connection(7).await;
+
+        let frame = sse_frame(&tunnel, &Message::Close { conn_id: 7 });
+        tunnel.handle_sse_message(&frame).await;
+
+        assert!(matches!(rx.try_recv(), Ok(TunnelEvent::Close)));
+    }
+
+    #[tokio::test]
+    async fn exit_status_delivers_an_exit_event() {
+        let tunnel = test_tunnel("pw");
+        let mut rx = tunnel.register_connection(3).await;
+
+        let frame = sse_frame(&tunnel, &Message::ExitStatus { conn_id: 3, code: 42 });
+        tunnel.handle_sse_message(&frame).await;
+
+        assert!(matches!(rx.try_recv(), Ok(TunnelEvent::Exit(42))));
+    }
+
+    #[tokio::test]
+    async fn reset_clears_channels_and_closes_every_receiver() {
+        let tunnel = test_tunnel("pw");
+        let mut rx1 = tunnel.register_connection(1).await;
+        let mut rx2 = tunnel.register_connection(2).await;
+        assert_eq!(tunnel.response_channels.lock().await.len(), 2);
+
+        let frame = sse_frame(&tunnel, &Message::Reset);
+        tunnel.handle_sse_message(&frame).await;
+
+        // The map is emptied...
+        assert!(tunnel.response_channels.lock().await.is_empty());
+        // ...and each dropped sender closes its receiver, so the relay tasks
+        // waiting on event_rx observe None and exit.
+        assert!(rx1.recv().await.is_none());
+        assert!(rx2.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn data_for_an_unknown_conn_is_a_silent_no_op() {
+        let tunnel = test_tunnel("pw");
+        // No registration for conn 99: must not panic and must not register one.
+        let frame = sse_frame(&tunnel, &Message::Data { conn_id: 99, data: vec![1, 2, 3] });
+        tunnel.handle_sse_message(&frame).await;
+        assert!(tunnel.response_channels.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn undecryptable_frame_is_dropped_without_dispatch() {
+        let tunnel = test_tunnel("right-pw");
+        let mut rx = tunnel.register_connection(1).await;
+
+        // Frame encrypted under a different key fails to decrypt and is ignored.
+        let wrong = Crypto::new("wrong-pw").unwrap();
+        let bytes = Message::Data { conn_id: 1, data: b"x".to_vec() }.to_bytes().unwrap();
+        let frame = wrong.encrypt(&bytes).unwrap();
+        tunnel.handle_sse_message(&frame).await;
+
+        assert!(rx.try_recv().is_err(), "nothing should have been delivered");
+    }
+}

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -28,7 +28,7 @@ pub struct Tunnel {
     pub hot: Arc<ArcSwap<HotClientConfig>>,
     pub response_channels: Arc<Mutex<HashMap<u32, mpsc::Sender<TunnelEvent>>>>,
     pub reconnect_signal: Arc<Notify>,
-    sse_ready: Notify,
+    sse_ready: Arc<Notify>,
 }
 
 impl Tunnel {
@@ -55,7 +55,7 @@ impl Tunnel {
             hot,
             response_channels: Arc::new(Mutex::new(HashMap::new())),
             reconnect_signal: Arc::new(Notify::new()),
-            sse_ready: Notify::new(),
+            sse_ready: Arc::new(Notify::new()),
         });
 
         // Test connection with health check
@@ -73,6 +73,14 @@ impl Tunnel {
             );
         }
 
+        // Register interest in the first "SSE ready" notification BEFORE spawning
+        // the reader (via enable()), so we can't miss it if the stream connects
+        // fast. We hold a cloned Arc so the future doesn't borrow `tunnel`.
+        let sse_ready = tunnel.sse_ready.clone();
+        let ready = sse_ready.notified();
+        tokio::pin!(ready);
+        ready.as_mut().enable();
+
         // Open SSE stream
         let tunnel_clone = tunnel.clone();
         tokio::spawn(async move {
@@ -87,8 +95,12 @@ impl Tunnel {
             }
         });
 
-        // Wait a moment for SSE to establish
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        // Wait for the stream to actually establish — the server creates the
+        // session when it handles GET /stream, so the first POST /send must not
+        // race ahead of it (otherwise: 503 "unknown session").
+        if tokio::time::timeout(Duration::from_secs(10), ready).await.is_err() {
+            warn!("SSE stream not ready after 10s; proceeding anyway");
+        }
 
         Ok(tunnel)
     }
@@ -107,12 +119,16 @@ impl Tunnel {
         }
 
         info!("SSE stream connected");
-        self.sse_ready.notify_waiters();
 
         use futures::StreamExt;
         let mut stream = resp.bytes_stream();
 
         let mut buffer = String::new();
+        // Signal readiness only AFTER the first chunk is processed. On a new
+        // session the server's first SSE frame is `Reset` (which clears pending
+        // channels); waiting for it to be handled before `connect()` returns
+        // ensures the first registration + POST can't be wiped by a late Reset.
+        let mut signaled_ready = false;
 
         loop {
             tokio::select! {
@@ -144,6 +160,11 @@ impl Tunnel {
                                 }
                             }
                         }
+                    }
+
+                    if !signaled_ready {
+                        self.sse_ready.notify_waiters();
+                        signaled_ready = true;
                     }
                 }
                 _ = self.reconnect_signal.notified() => {

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -18,6 +18,8 @@ pub enum TunnelEvent {
     Data(Vec<u8>),
     Close,
     Error(String),
+    /// Remote process exited with this code (remote exec).
+    Exit(i32),
 }
 
 /// Tunnel handles communication with the server via SSE + HTTP POST
@@ -208,6 +210,16 @@ impl Tunnel {
                     if let Some(tx) = tx {
                         let _ = tx.send(TunnelEvent::Error(message)).await;
                     }
+                }
+            }
+            Message::ExitStatus { conn_id, code } => {
+                debug!("[{}] SSE exit status {}", conn_id, code);
+                let tx = {
+                    let channels = self.response_channels.lock().await;
+                    channels.get(&conn_id).cloned()
+                };
+                if let Some(tx) = tx {
+                    let _ = tx.send(TunnelEvent::Exit(code)).await;
                 }
             }
             Message::Reset => {

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -92,14 +92,17 @@ impl Tunnel {
             // retry for the full RECONNECT_WAIT (10s) timeout.
             let mut is_reconnect = false;
             loop {
-                if let Err(e) = tunnel_clone.sse_read_loop(is_reconnect).await {
-                    if e.to_string().contains("forced reconnect") {
-                        is_reconnect = true;
-                        continue;
+                let res = tunnel_clone.sse_read_loop(is_reconnect).await;
+                is_reconnect = true;
+                match res {
+                    Err(e) if e.to_string().contains("forced reconnect") => continue,
+                    Err(e) => {
+                        error!("SSE stream error: {}, reconnecting in 3s...", e);
+                        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                     }
-                    error!("SSE stream error: {}, reconnecting in 3s...", e);
-                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                    is_reconnect = true;
+                    Ok(()) => {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
                 }
             }
         });

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -124,10 +124,13 @@ impl Tunnel {
         let mut stream = resp.bytes_stream();
 
         let mut buffer = String::new();
-        // Signal readiness only AFTER the first chunk is processed. On a new
-        // session the server's first SSE frame is `Reset` (which clears pending
-        // channels); waiting for it to be handled before `connect()` returns
-        // ensures the first registration + POST can't be wiped by a late Reset.
+        // Signal readiness only AFTER the first `data:` frame is processed. On a
+        // new session the server's first data frame is `Reset` (which clears
+        // pending channels); handling it before `connect()` returns ensures the
+        // first registration + POST can't be wiped by a late Reset. We can't just
+        // wait for the first chunk: the server's keepalive `:\n\n` comment can be
+        // emitted ahead of the queued Reset (its interval's first tick is
+        // immediate), so only a real data frame guarantees the Reset is consumed.
         let mut signaled_ready = false;
 
         loop {
@@ -153,6 +156,10 @@ impl Tunnel {
                                 match Base64::decode_vec(data_str.trim()) {
                                     Ok(encrypted) => {
                                         self.handle_sse_message(&encrypted).await;
+                                        if !signaled_ready {
+                                            self.sse_ready.notify_waiters();
+                                            signaled_ready = true;
+                                        }
                                     }
                                     Err(e) => {
                                         warn!("Base64 decode error: {}", e);
@@ -160,11 +167,6 @@ impl Tunnel {
                                 }
                             }
                         }
-                    }
-
-                    if !signaled_ready {
-                        self.sse_ready.notify_waiters();
-                        signaled_ready = true;
                     }
                 }
                 _ = self.reconnect_signal.notified() => {

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -84,13 +84,22 @@ impl Tunnel {
         // Open SSE stream
         let tunnel_clone = tunnel.clone();
         tokio::spawn(async move {
+            // First iteration is the initial connect — gate readiness on the
+            // first `data:` frame so a fresh-session Reset is consumed before
+            // `register_connection` lands. On reconnects, the server won't send
+            // a Reset and the first event may be a keepalive comment; in that
+            // case signal on any event to avoid stalling `send_message`'s
+            // retry for the full RECONNECT_WAIT (10s) timeout.
+            let mut is_reconnect = false;
             loop {
-                if let Err(e) = tunnel_clone.sse_read_loop().await {
+                if let Err(e) = tunnel_clone.sse_read_loop(is_reconnect).await {
                     if e.to_string().contains("forced reconnect") {
+                        is_reconnect = true;
                         continue;
                     }
                     error!("SSE stream error: {}, reconnecting in 3s...", e);
                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                    is_reconnect = true;
                 }
             }
         });
@@ -106,7 +115,7 @@ impl Tunnel {
     }
 
     /// Read SSE events and dispatch to connection handlers
-    async fn sse_read_loop(&self) -> Result<()> {
+    async fn sse_read_loop(&self, is_reconnect: bool) -> Result<()> {
         let hot = self.hot.load();
         let sid = self.session_id.read().await;
         let url = format!("{}/stream/{}", hot.server_base_url, *sid);
@@ -124,13 +133,18 @@ impl Tunnel {
         let mut stream = resp.bytes_stream();
 
         let mut buffer = String::new();
-        // Signal readiness only AFTER the first `data:` frame is processed. On a
-        // new session the server's first data frame is `Reset` (which clears
-        // pending channels); handling it before `connect()` returns ensures the
-        // first registration + POST can't be wiped by a late Reset. We can't just
-        // wait for the first chunk: the server's keepalive `:\n\n` comment can be
-        // emitted ahead of the queued Reset (its interval's first tick is
-        // immediate), so only a real data frame guarantees the Reset is consumed.
+        // On the initial connect, signal readiness only AFTER the first
+        // `data:` frame is processed: a new session's first data frame is
+        // `Reset` (which clears pending channels), and handling it before
+        // `connect()` returns ensures the first registration + POST can't be
+        // wiped by a late Reset. We can't just wait for the first chunk: the
+        // server's keepalive `:\n\n` comment can be emitted ahead of the
+        // queued Reset (its interval's first tick is immediate), so only a
+        // real data frame guarantees the Reset is consumed.
+        //
+        // On reconnects the server won't queue a Reset, so the first event may
+        // be a keepalive; signal on any event to avoid stalling send_message
+        // for the full RECONNECT_WAIT (10s) timeout.
         let mut signaled_ready = false;
 
         loop {
@@ -151,21 +165,30 @@ impl Tunnel {
                         let event = buffer[..pos].to_string();
                         buffer = buffer[pos + 2..].to_string();
 
+                        let mut had_data = false;
                         for line in event.lines() {
                             if let Some(data_str) = line.strip_prefix("data: ") {
                                 match Base64::decode_vec(data_str.trim()) {
                                     Ok(encrypted) => {
                                         self.handle_sse_message(&encrypted).await;
-                                        if !signaled_ready {
-                                            self.sse_ready.notify_waiters();
-                                            signaled_ready = true;
-                                        }
+                                        had_data = true;
                                     }
                                     Err(e) => {
                                         warn!("Base64 decode error: {}", e);
                                     }
                                 }
                             }
+                        }
+                        if had_data && !signaled_ready {
+                            self.sse_ready.notify_waiters();
+                            signaled_ready = true;
+                        } else if is_reconnect && !signaled_ready {
+                            // Keepalive comment — the stream is up and the
+                            // server is not going to send a Reset. Notify
+                            // send_message's retry path so it doesn't burn
+                            // the full 10s RECONNECT_WAIT.
+                            self.sse_ready.notify_waiters();
+                            signaled_ready = true;
                         }
                     }
                 }

--- a/wiki/enriched-context.md
+++ b/wiki/enriched-context.md
@@ -86,4 +86,4 @@ If a non-PTY / non-canonical mode is needed, that's a separate feature (`--no-pt
 These are deliberate, operator-driven decisions. Do not "fix" them in a security-pass without coordination.
 
 *   **`danger_accept_invalid_certs(true)` in `reload.rs::build_http_client`** — intentional. Deployments behind a corporate TLS-inspecting proxy (re-signed certs from a MITM CA) need this to complete the handshake.
-*   **`tunnix server --allow-exec`** — opt-in only, default `false`, and the server prints a loud warning at startup when it's on. Anyone holding the server password can run a shell on the box. This features is designed to give remote user GOD MODE to the server.
+*   **`tunnix server --allow-exec`** — opt-in only, default `false`, and the server prints a loud warning at startup when it's on. Anyone holding the server password can run a shell on the box. This feature is designed to give remote user GOD MODE to the server.

--- a/wiki/enriched-context.md
+++ b/wiki/enriched-context.md
@@ -67,3 +67,12 @@ GET /path HTTP/1.1
 ## Buffer sizes
 
 The relay uses 32 KB read buffers (`relay.rs`). The SSE event channel per connection has a buffer of 256 messages (`tunnel.rs: mpsc::channel(256)`). These are not configurable at runtime; change them in code if throughput is a bottleneck.
+
+---
+
+## Intentional security trade-offs
+
+These are deliberate, operator-driven decisions. Do not "fix" them in a security-pass without coordination.
+
+*   **`danger_accept_invalid_certs(true)` in `reload.rs::build_http_client`** — intentional. Deployments behind a corporate TLS-inspecting proxy (re-signed certs from a MITM CA) need this to complete the handshake.
+*   **`tunnix server --allow-exec`** — opt-in only, default `false`, and the server prints a loud warning at startup when it's on. Anyone holding the server password can run a shell on the box. This is the documented feature, not a vulnerability; the warning is the contract.

--- a/wiki/enriched-context.md
+++ b/wiki/enriched-context.md
@@ -70,6 +70,17 @@ The relay uses 32 KB read buffers (`relay.rs`). The SSE event channel per connec
 
 ---
 
+## `remote-exec` allocates a PTY in canonical mode
+
+`remote-exec` always allocates a pseudo-terminal (PTY) for the child process, with the slave PTY left in its default canonical (line-buffered) mode. This is the right shape for interactive use (`vim`, `bash`, top) but has two consequences for non-interactive use:
+
+*   **Piped stdin ending without a trailing newline gets one injected before EOF.** `printf abc | tunnix remote-exec sha256sum` hashes `"abc\n"`, not `"abc"`. The PTY's terminal driver delivers line-buffered data only on `\n` or VEOF; VEOF on a non-empty buffer flushes it but does *not* signal EOF. To get a real EOF the driver must first see the line terminator, so `exec.rs` synthesizes a `'\n'` before the `\x04` it sends on local EOF. The output the child sees is exactly what it would see if you had typed `abc<Enter><Ctrl-D>` interactively — but it is *not* byte-identical to the bytes the caller sent on the pipe.
+*   **Binary data through `remote-exec` is not safe.** Canonical mode also drops/parities certain bytes (^C, ^Z, ^\). For byte-fidelity use, run the command locally and tunnel only its TCP traffic through tunnix; do not pipe binary into `remote-exec`.
+
+If a non-PTY / non-canonical mode is needed, that's a separate feature (`--no-pty` or similar), not a bug to fix in the current PTY path.
+
+---
+
 ## Intentional security trade-offs
 
 These are deliberate, operator-driven decisions. Do not "fix" them in a security-pass without coordination.

--- a/wiki/enriched-context.md
+++ b/wiki/enriched-context.md
@@ -75,4 +75,4 @@ The relay uses 32 KB read buffers (`relay.rs`). The SSE event channel per connec
 These are deliberate, operator-driven decisions. Do not "fix" them in a security-pass without coordination.
 
 *   **`danger_accept_invalid_certs(true)` in `reload.rs::build_http_client`** — intentional. Deployments behind a corporate TLS-inspecting proxy (re-signed certs from a MITM CA) need this to complete the handshake.
-*   **`tunnix server --allow-exec`** — opt-in only, default `false`, and the server prints a loud warning at startup when it's on. Anyone holding the server password can run a shell on the box. This is the documented feature, not a vulnerability; the warning is the contract.
+*   **`tunnix server --allow-exec`** — opt-in only, default `false`, and the server prints a loud warning at startup when it's on. Anyone holding the server password can run a shell on the box. This features is designed to give remote user GOD MODE to the server.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unix-only remote command execution with interactive PTY support and a RemoteExec CLI subcommand.
  * Opt-in server setting/CLI flag to enable remote exec (disabled by default).
  * Terminal resize updates and remote exit-status reporting.

* **Bug Fixes / Improvements**
  * Cleaner session shutdown and exit-code handling; writer task termination on exit events.
  * Faster connection readiness signaling to reduce send stalls and retries.

* **Documentation**
  * Expanded config and wiki guidance on PTY behavior and security trade-offs.

* **Tests**
  * Added protocol round-trip tests for exec-related messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->