### PR TITLE
fix: change logging output from stdout to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,13 +205,13 @@ async fn main() -> Result<()> {
         _ => Level::INFO,
     };
 
-    let stdout_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stdout)
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
         .with_target(false);
 
     let registry = tracing_subscriber::registry()
         .with(tracing_subscriber::filter::LevelFilter::from_level(level))
-        .with(stdout_layer);
+        .with(stderr_layer);
 
     if let Some(ref log_path) = args.log {
         let log_file = std::fs::OpenOptions::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,7 +428,7 @@ async fn main() -> Result<()> {
             let locals: Vec<std::path::PathBuf> = sources.iter().map(Into::into).collect();
             let tun = connect_transfer_tunnel(&mut config, ta.server, ta.password, ta.cookie).await?;
             transfer::push(tun, locals, dest.clone(), ta.level).await?;
-            println!("push complete");
+            eprintln!("push complete");
         }
 
         Command::Pull(ta) => {
@@ -436,7 +436,7 @@ async fn main() -> Result<()> {
             let (dest, sources) = ta.paths.split_last().unwrap();
             let tun = connect_transfer_tunnel(&mut config, ta.server, ta.password, ta.cookie).await?;
             transfer::pull(tun, sources.to_vec(), dest.into(), ta.level).await?;
-            println!("pull complete");
+            eprintln!("pull complete");
         }
     }
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -11,6 +11,11 @@ use crate::protocol::Message;
 use crate::reload::{build_http_client, HotClientConfig};
 
 const RECONNECT_WAIT: Duration = Duration::from_secs(10);
+/// Bound on establishing the SSE GET (connect + response headers). The
+/// http_client has no global timeout (it would kill the streaming body), and
+/// a half-open pooled connection otherwise wedges `send().await` forever —
+/// the reconnect task is the only one, so the whole tunnel dies silently.
+const SSE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Events received from server via SSE
 #[derive(Debug)]
@@ -124,13 +129,24 @@ impl Tunnel {
         let url = format!("{}/stream/{}", hot.server_base_url, *sid);
         info!("Opening SSE stream for session {} at {}", sid, hot.server_base_url);
         drop(sid);
-        let resp = hot.http_client.get(&url).send().await?;
+        // `send()` resolves at response headers, so this bounds only the
+        // connection setup, not the long-lived streaming body.
+        let resp = tokio::time::timeout(SSE_CONNECT_TIMEOUT, hot.http_client.get(&url).send())
+            .await
+            .map_err(|_| anyhow::anyhow!("SSE connect timed out after {:?}", SSE_CONNECT_TIMEOUT))??;
 
         if !resp.status().is_success() {
             anyhow::bail!("SSE stream failed: {}", resp.status());
         }
 
         info!("SSE stream connected");
+
+        // Drain any reconnect permit buffered while we were connecting
+        // (send_message fires notify_one on POST failure; if it fired during
+        // the GET above, the permit would otherwise tear down this freshly
+        // established stream on the first select! iteration).
+        use futures::FutureExt;
+        let _ = self.reconnect_signal.notified().now_or_never();
 
         use futures::StreamExt;
         let mut stream = resp.bytes_stream();
@@ -294,39 +310,41 @@ impl Tunnel {
         let bytes = msg.to_bytes()?;
         let encrypted = hot.crypto.encrypt(&bytes)?;
 
-        let initial_sid = self.session_id.read().await.clone();
+        let sid = self.session_id.read().await.clone();
 
-        match self.try_post(&encrypted).await {
+        match self.try_post(&sid, &encrypted).await {
             Ok(v) => Ok(v),
             Err(first_err) => {
-                let err_str = first_err.to_string();
-                if err_str.contains("unknown session") {
-                    let mut sid = self.session_id.write().await;
-                    if *sid == initial_sid {
-                        warn!("Server lost session; generating new session ID");
-                        *sid = format!("{:016x}", rand::random::<u64>());
-                        let mut channels = self.response_channels.lock().await;
-                        channels.clear();
-                    } else {
-                        debug!("Session already updated by another thread, skipping generation");
-                    }
-                }
-
+                // Any failure — including 503 "unknown session" after a
+                // server restart — is handled by forcing an SSE reconnect
+                // and retrying once. The session ID is deliberately NOT
+                // rotated: the server (re)creates the session on
+                // GET /stream/{sid}, and a genuinely fresh session announces
+                // itself with Reset, which clears stale conn state. Keeping
+                // the ID stable lets concurrent failures converge on one
+                // reconnect instead of racing to rotate (the old "death
+                // spiral"), and preserves in-flight server relays when the
+                // server didn't actually restart.
                 warn!("send failed: {}; forcing SSE reconnect and retrying", first_err);
+                // Register interest BEFORE signaling, so the SSE task can't
+                // win the race and fire sse_ready between notify_one and our
+                // first poll.
                 let ready = self.sse_ready.notified();
                 tokio::pin!(ready);
+                ready.as_mut().enable();
                 self.reconnect_signal.notify_one();
                 let _ = tokio::time::timeout(RECONNECT_WAIT, ready).await;
-                self.try_post(&encrypted).await
+                // Re-read: the hot-reload watcher may have rotated the sid
+                // (password/header change) while we waited.
+                let sid = self.session_id.read().await.clone();
+                self.try_post(&sid, &encrypted).await
             }
         }
     }
 
-    async fn try_post(&self, encrypted: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn try_post(&self, sid: &str, encrypted: &[u8]) -> Result<Option<Vec<u8>>> {
         let hot = self.hot.load();
-        let sid = self.session_id.read().await;
-        let url = format!("{}/send/{}", hot.server_base_url, *sid);
-        drop(sid);
+        let url = format!("{}/send/{}", hot.server_base_url, sid);
         let resp = hot
             .http_client
             .post(&url)

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -10,12 +10,16 @@ use crate::crypto::Crypto;
 use crate::protocol::Message;
 use crate::reload::{build_http_client, HotClientConfig};
 
-const RECONNECT_WAIT: Duration = Duration::from_secs(10);
 /// Bound on establishing the SSE GET (connect + response headers). The
 /// http_client has no global timeout (it would kill the streaming body), and
 /// a half-open pooled connection otherwise wedges `send().await` forever —
 /// the reconnect task is the only one, so the whole tunnel dies silently.
 const SSE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Time send_message waits for the SSE stream to become ready after forcing
+/// a reconnect. Must exceed SSE_CONNECT_TIMEOUT (15s): the GET alone can take
+/// that long under network congestion, and this also covers first-frame
+/// processing before sse_ready fires.
+const RECONNECT_WAIT: Duration = Duration::from_secs(20);
 
 /// Events received from server via SSE
 #[derive(Debug)]
@@ -94,7 +98,7 @@ impl Tunnel {
             // `register_connection` lands. On reconnects, the server won't send
             // a Reset and the first event may be a keepalive comment; in that
             // case signal on any event to avoid stalling `send_message`'s
-            // retry for the full RECONNECT_WAIT (10s) timeout.
+            // retry for the full RECONNECT_WAIT timeout.
             let mut is_reconnect = false;
             loop {
                 let res = tunnel_clone.sse_read_loop(is_reconnect).await;
@@ -115,8 +119,8 @@ impl Tunnel {
         // Wait for the stream to actually establish — the server creates the
         // session when it handles GET /stream, so the first POST /send must not
         // race ahead of it (otherwise: 503 "unknown session").
-        if tokio::time::timeout(Duration::from_secs(10), ready).await.is_err() {
-            warn!("SSE stream not ready after 10s; proceeding anyway");
+        if tokio::time::timeout(RECONNECT_WAIT, ready).await.is_err() {
+            warn!("SSE stream not ready after {:?}; proceeding anyway", RECONNECT_WAIT);
         }
 
         Ok(tunnel)
@@ -128,6 +132,7 @@ impl Tunnel {
         let sid = self.session_id.read().await;
         let url = format!("{}/stream/{}", hot.server_base_url, *sid);
         info!("Opening SSE stream for session {} at {}", sid, hot.server_base_url);
+        let captured_sid = sid.clone();
         drop(sid);
         // `send()` resolves at response headers, so this bounds only the
         // connection setup, not the long-lived streaming body.
@@ -145,8 +150,22 @@ impl Tunnel {
         // (send_message fires notify_one on POST failure; if it fired during
         // the GET above, the permit would otherwise tear down this freshly
         // established stream on the first select! iteration).
-        use futures::FutureExt;
-        let _ = self.reconnect_signal.notified().now_or_never();
+        //
+        // Only drain if the session_id hasn't changed: the config watcher
+        // rotates the session_id *before* firing reconnect_signal, so a
+        // changed sid means its permit is in-flight and must NOT be consumed
+        // (otherwise the stream stays on the old session). Holding the read
+        // lock during the drain prevents the config watcher from rotating
+        // mid-check, since it needs the write lock first.
+        let current_sid = self.session_id.read().await;
+        if *current_sid == captured_sid {
+            use futures::FutureExt;
+            let _ = self.reconnect_signal.notified().now_or_never();
+        } else {
+            drop(current_sid);
+            anyhow::bail!("forced reconnect");
+        }
+        drop(current_sid);
 
         use futures::StreamExt;
         let mut stream = resp.bytes_stream();
@@ -163,7 +182,7 @@ impl Tunnel {
         //
         // On reconnects the server won't queue a Reset, so the first event may
         // be a keepalive; signal on any event to avoid stalling send_message
-        // for the full RECONNECT_WAIT (10s) timeout.
+        // for the full RECONNECT_WAIT timeout.
         let mut signaled_ready = false;
 
         loop {
@@ -205,7 +224,7 @@ impl Tunnel {
                             // Keepalive comment — the stream is up and the
                             // server is not going to send a Reset. Notify
                             // send_message's retry path so it doesn't burn
-                            // the full 10s RECONNECT_WAIT.
+                            // the full RECONNECT_WAIT.
                             self.sse_ready.notify_waiters();
                             signaled_ready = true;
                         }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -327,11 +327,11 @@ impl Tunnel {
     pub async fn send_message(&self, msg: &Message) -> Result<Option<Vec<u8>>> {
         let hot = self.hot.load();
         let bytes = msg.to_bytes()?;
-        let encrypted = hot.crypto.encrypt(&bytes)?;
+        let encrypted = bytes::Bytes::from(hot.crypto.encrypt(&bytes)?);
 
         let sid = self.session_id.read().await.clone();
 
-        match self.try_post(&sid, &encrypted).await {
+        match self.try_post(&sid, encrypted.clone()).await {
             Ok(v) => Ok(v),
             Err(first_err) => {
                 // Any failure — including 503 "unknown session" after a
@@ -356,18 +356,18 @@ impl Tunnel {
                 // Re-read: the hot-reload watcher may have rotated the sid
                 // (password/header change) while we waited.
                 let sid = self.session_id.read().await.clone();
-                self.try_post(&sid, &encrypted).await
+                self.try_post(&sid, encrypted).await
             }
         }
     }
 
-    async fn try_post(&self, sid: &str, encrypted: &[u8]) -> Result<Option<Vec<u8>>> {
+    async fn try_post(&self, sid: &str, encrypted: bytes::Bytes) -> Result<Option<Vec<u8>>> {
         let hot = self.hot.load();
         let url = format!("{}/send/{}", hot.server_base_url, sid);
         let resp = hot
             .http_client
             .post(&url)
-            .body(encrypted.to_vec())
+            .body(encrypted)
             .send()
             .await?;
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -89,9 +89,11 @@ Each connection gets a unique `conn_id` used to demultiplex messages on the sing
 
 Maintains a long-lived SSE connection (`GET /stream/{session_id}`) for server-to-client messages. The SSE loop runs in a background task and uses a `tokio::select!` to interleave stream reads with a `reconnect_signal` (`Notify`), allowing `send_message` to force an immediate reconnect when a POST fails rather than waiting for the underlying TCP read to time out.
 
-`session_id` is stored in an `RwLock<String>` (not a plain `String`) so concurrent callers can read it without contention, and a single writer can rotate it atomically when the server reports an unknown session (HTTP 503). All pending `response_channels` are cleared at the same time.
+`session_id` is stored in an `RwLock<String>` (not a plain `String`) so concurrent callers can read it without contention, and the hot-reload watcher can rotate it atomically on a password/header change. It is deliberately **not** rotated when the server reports an unknown session (HTTP 503): the server (re)creates a session on `GET /stream/{sid}` and announces freshness with `Reset`, so recovery only needs a forced SSE reconnect. Keeping the ID stable lets concurrent send failures converge on one reconnect instead of racing to rotate (the old "death spiral"), and preserves in-flight server relays when the server didn't actually restart.
 
-`send_message` — tries `try_post` once; on failure it signals `reconnect_signal`, waits up to `RECONNECT_WAIT` for `sse_ready` (fired by the SSE loop on each fresh connection), then retries `try_post` once more.
+`send_message` — tries `try_post` once; on any failure it signals `reconnect_signal`, waits up to `RECONNECT_WAIT` for `sse_ready` (fired by the SSE loop on each fresh connection), then retries `try_post` once more.
+
+Establishing the SSE `GET` is bounded by a 15s timeout (`SSE_CONNECT_TIMEOUT`): the http_client has no global timeout (it would kill the streaming body), and a half-open pooled connection would otherwise wedge `send().await` forever — the reconnect task is the only one, so the whole tunnel would die silently. After each successful (re)connect, any `reconnect_signal` permit buffered during connection setup is drained so it can't tear down the freshly established stream.
 
 `send_connect()` — sends a `Connect` message and synchronously reads the **HTTP response body** as the ACK. This is distinct from the SSE stream; the ACK is the POST response, not an SSE event.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel reliability by preventing connection setup from hanging indefinitely and making reconnects more dependable.
  * Reduced false disconnects after a successful reconnect and improved retry behavior when sending requests.
  * Status and completion messages now appear on error output, keeping normal output cleaner.

* **Documentation**
  * Updated architecture notes to reflect the new reconnect and session-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->