### PR TITLE
fix: half-close semantics and bounded teardown in the TCP relay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,10 @@ path = "src/main.rs"
 
 [dependencies]
 # Async runtime
-# 1.51: TcpStream::set_zero_linger, used by the relay to abort a failed
-# connection with a RST instead of a FIN the app would read as a clean EOF.
+# TcpStream::set_zero_linger (added in tokio 1.50) lets the relay abort a
+# failed connection with a RST instead of a FIN the app would read as a clean
+# EOF. The floor is kept at 1.51, the version this is actually built and
+# tested against; 1.50 would satisfy the API alone.
 tokio = { version = "1.51", features = ["full"] }
 rustls = { version = "0.23", features = ["ring"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "tunnix"
 version = "0.4.1"
 edition = "2021"
+# Floor of the locked dependency tree (cookie_store 0.22 declares 1.88; tokio
+# 1.51, pulled in for TcpStream::set_zero_linger, needs 1.71). Lets cargo report
+# an old toolchain up front instead of failing deep inside a dependency build.
+rust-version = "1.88"
 authors = ["Aero Wang <aero.windwalker@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/aeroxy/tunnix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,8 @@ shlex = "1.3"
 libc = "0.2"
 portable-pty = "0.9"
 nix = { version = "0.29", features = ["fs", "term"] }
+
+[dev-dependencies]
+# `#[tokio::test(start_paused = true)]` lets timeout-driven tests run instantly.
+# Dev-only so the test clock never ships in a release build.
+tokio = { version = "1.40", features = ["full", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ path = "src/main.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.40", features = ["full"] }
+# 1.51: TcpStream::set_zero_linger, used by the relay to abort a failed
+# connection with a RST instead of a FIN the app would read as a clean EOF.
+tokio = { version = "1.51", features = ["full"] }
 rustls = { version = "0.23", features = ["ring"] }
 
 # Encryption
@@ -77,4 +79,4 @@ nix = { version = "0.29", features = ["fs", "term"] }
 [dev-dependencies]
 # `#[tokio::test(start_paused = true)]` lets timeout-driven tests run instantly.
 # Dev-only so the test clock never ships in a release build.
-tokio = { version = "1.40", features = ["full", "test-util"] }
+tokio = { version = "1.51", features = ["full", "test-util"] }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -82,6 +82,20 @@ pub enum Message {
         conn_id: u32,
         path: String,
     },
+
+    /// Client tells the server a connection is dead on its side: the proxied
+    /// app aborted, or the client's relay failed. Unlike `Close`, which only
+    /// half-closes the upload direction and leaves the target's output
+    /// flowing, this releases the target entirely - the server stops reading
+    /// it and drops the socket. Without it an abandoned download is pulled to
+    /// completion into a conn_id the client no longer knows.
+    ///
+    /// Appended last so existing variant indices are unchanged on the wire.
+    /// An older server fails to decode it and answers 200, so mixed versions
+    /// degrade to the previous behaviour rather than breaking.
+    Abort {
+        conn_id: u32,
+    },
 }
 
 impl Message {
@@ -119,6 +133,15 @@ mod tests {
             }
             _ => panic!("Wrong message type"),
         }
+    }
+
+    #[test]
+    fn test_abort_message() {
+        let bytes = Message::Abort { conn_id: 9 }.to_bytes().unwrap();
+        assert!(matches!(
+            Message::from_bytes(&bytes).unwrap(),
+            Message::Abort { conn_id: 9 }
+        ));
     }
 
     #[test]

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -44,11 +44,23 @@ pub async fn relay(
     // knows no further failure report can arrive.
     let upload_done = Arc::new(Notify::new());
     let upload_done_write = upload_done.clone();
+    // Raised instead when the upload side ended in failure rather than at the
+    // app's EOF. The write half has to hear that unconditionally: a broken
+    // tunnel produces no events at all, so waiting for a terminal one that
+    // cannot arrive would park this relay - and the app with it - indefinitely.
+    let upload_failed = Arc::new(Notify::new());
+    let upload_failed_write = upload_failed.clone();
 
     let read_task = tokio::spawn(async move {
         let mut buf = vec![0u8; 32768];
-        // Set when the write half stopped us after the server reported failure.
-        let mut stopped_by_server = false;
+        // Set when the write half stopped us because the connection failed.
+        // Says nothing about *whose* failure it was - `server_reported` is the
+        // flag that means the server reported it.
+        let mut stopped_by_write_half = false;
+        // Set when the upload side itself broke - the app's socket errored, or
+        // the tunnel would not take the chunk. Either way this connection is
+        // dead, as opposed to the app simply being done sending.
+        let mut local_failure = false;
         loop {
             let read = tokio::select! {
                 // Biased toward the failure signal: once the connection has
@@ -58,7 +70,7 @@ pub async fn relay(
                 biased;
                 _ = failed_read.notified() => {
                     debug!("[{}] connection failed; stopping the upload side", conn_id);
-                    stopped_by_server = true;
+                    stopped_by_write_half = true;
                     break;
                 }
                 // Cancel-safe: no bytes are consumed if the other branch wins.
@@ -77,11 +89,13 @@ pub async fn relay(
                     };
                     if let Err(e) = tunnel_clone.send_message(&msg).await {
                         error!("[{}] tunnel send error: {}", conn_id, e);
+                        local_failure = true;
                         break;
                     }
                 }
                 Err(e) => {
                     debug!("[{}] client read error: {}", conn_id, e);
+                    local_failure = true;
                     break;
                 }
             }
@@ -99,9 +113,10 @@ pub async fn relay(
         // when the server itself reported the failure, having already released
         // the writer: the POST would be redundant, and on a broken tunnel it
         // costs a full reconnect wait before failing anyway.
-        if !(stopped_by_server && server_reported_read.load(Ordering::SeqCst)) {
+        let aborting = stopped_by_write_half || local_failure;
+        if !(stopped_by_write_half && server_reported_read.load(Ordering::SeqCst)) {
             let close_msg = Message::Close { conn_id };
-            if stopped_by_server {
+            if aborting {
                 // This connection is about to be aborted, and the app is
                 // waiting on a response that will never arrive - it has to find
                 // that out now. send_message can spend a full RECONNECT_WAIT on
@@ -117,8 +132,13 @@ pub async fn relay(
             }
         }
 
-        // Let the write half stop waiting for a late failure report.
-        upload_done.notify_one();
+        // Let the write half stop waiting: cleanly if the app just finished
+        // sending, as a failure if the upload broke.
+        if local_failure {
+            upload_failed.notify_one();
+        } else {
+            upload_done.notify_one();
+        }
         tcp_read
     });
 
@@ -147,6 +167,11 @@ pub async fn relay(
                         break;
                     }
                 },
+                _ = upload_failed_write.notified() => {
+                    debug!("[{}] upload side failed; failing the connection", conn_id);
+                    failed = true;
+                    break;
+                }
                 _ = upload_done_write.notified(), if response_closed => {
                     debug!("[{}] upload finished; nothing left to report", conn_id);
                     break;
@@ -187,10 +212,11 @@ pub async fn relay(
 
         // The channel was dropped before the upload finished: the server
         // session was reset, or the dispatcher dropped this connection as
-        // stalled. Before Close that truncates the response. After Close the
-        // response is complete, but the upload still in progress now lands on
-        // a server that no longer knows this conn_id and discards it with a
-        // 200. Both are failures the app has to see, not a clean EOF.
+        // stalled. Before Close that truncates the response, and the app must
+        // not read it as a successful end-of-stream. After Close the response
+        // is complete, but an upload still in progress now lands on a server
+        // that no longer knows this conn_id and discards it with a 200 - so the
+        // upload has to stop, even though the response direction was fine.
         if channel_dropped {
             debug!("[{}] dispatch channel dropped before the connection finished", conn_id);
             failed = true;
@@ -201,7 +227,13 @@ pub async fn relay(
             // close its side on its own.
             failed_notify.notify_one();
         }
-        (tcp_write, failed)
+        // Abort only when the response was *not* already delivered in full.
+        // Once Close has been forwarded the app has every byte and a FIN;
+        // resetting then makes its kernel discard whatever it has not read
+        // yet, destroying a good response to report a failure on the other
+        // direction. The upload failing after that is reported by the app's
+        // own write failing, not by throwing away what it asked for.
+        (tcp_write, failed && !response_closed)
     });
 
     // Both directions run to completion independently: an upload that finishes
@@ -211,17 +243,18 @@ pub async fn relay(
     // On failure the write half signals the read half to stop, so both return
     // their socket halves and the connection can be aborted below.
     let (read_half, write_half) = tokio::join!(read_task, write_task);
-    let failed = matches!(&write_half, Ok((_, true)));
+    let abort = matches!(&write_half, Ok((_, true)));
 
     tunnel.unregister_connection(conn_id).await;
 
-    // A failed connection has to fail visibly. Dropping the socket sends FIN,
+    // A truncated response has to fail visibly. Dropping the socket sends FIN,
     // which the app reads as a successful end-of-stream on data that is in fact
     // truncated. Reuniting the halves and setting SO_LINGER to zero makes the
     // close a RST instead, so the app's read fails and it cannot mistake the
     // short stream for a complete one. Reunite consumes both halves, so no FIN
-    // escapes on the way.
-    if !failed {
+    // escapes on the way. A connection whose response *did* arrive in full is
+    // never aborted here - see the write half's return value.
+    if !abort {
         return;
     }
     let (Ok(read_half), Ok((write_half, _))) = (read_half, write_half) else {
@@ -302,10 +335,11 @@ mod tests {
     /// The channel can also be dropped *after* a clean Close, while the app is
     /// still uploading. The server that reset no longer knows the conn_id, so
     /// every further chunk is discarded with a 200. The relay must not sit
-    /// waiting for an app that has no reason to stop; it has to fail the
-    /// connection so the app finds out.
+    /// waiting for an app that has no reason to stop - it has to stop the
+    /// upload side itself. The response direction already completed, so the app
+    /// keeps the clean EOF it was given.
     #[tokio::test]
-    async fn a_dropped_dispatch_channel_after_close_still_fails_the_connection() {
+    async fn a_dropped_dispatch_channel_after_close_still_ends_the_relay() {
         const CONN_ID: u32 = 6;
 
         // Stand-in for the app: it holds its side open, never closing, the way
@@ -338,5 +372,144 @@ mod tests {
         finished
             .expect("relay kept waiting on the app after its channel was dropped")
             .expect("relay panicked");
+    }
+
+    /// A broken upload side must fail the connection, not park it. Nothing is
+    /// coming back down the response direction - the tunnel send failed, or the
+    /// app's socket died - so a write half that waits for a terminal event
+    /// waits forever, holding the relay and its conn_id registration open.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_upload_does_not_park_the_relay() {
+        use std::os::fd::AsRawFd;
+        const CONN_ID: u32 = 9;
+
+        // App that aborts its side: SO_LINGER with a zero timeout turns close()
+        // into a RST, so the relay's read half errors instead of seeing EOF.
+        let listener = StdListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Held until the relay is running: a reset that lands during connect()
+        // would fail the handshake instead of the relay's read.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let app = std::thread::spawn(move || {
+            let (sock, _) = listener.accept().unwrap();
+            let _ = release_rx.recv();
+            let linger = libc::linger { l_onoff: 1, l_linger: 0 };
+            unsafe {
+                libc::setsockopt(
+                    sock.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_LINGER,
+                    &linger as *const _ as *const libc::c_void,
+                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                );
+            }
+            drop(sock);
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tunnel = Arc::new(test_tunnel("pw"));
+        // Sender held, so the write half gets no channel-drop rescue: only the
+        // read half's failure can end it.
+        let (_event_tx, event_rx) = mpsc::channel(8);
+
+        let relay = tokio::spawn(relay(stream, CONN_ID, tunnel, event_rx));
+        let _ = release_tx.send(());
+        tokio::task::spawn_blocking(move || app.join().unwrap()).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), relay)
+            .await
+            .expect("relay parked after the upload side failed")
+            .expect("relay panicked");
+    }
+
+    /// A server `Error` before the response finished means the stream is
+    /// truncated, so the app has to be failed rather than handed a short read
+    /// that looks complete. This is also the only path that sets
+    /// `server_reported`, which suppresses the read half's teardown Close.
+    #[tokio::test]
+    async fn a_server_error_before_close_fails_the_connection() {
+        const CONN_ID: u32 = 7;
+
+        let listener = StdListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut got = Vec::new();
+            sock.read_to_end(&mut got).is_err()
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tunnel = Arc::new(test_tunnel("pw"));
+        let (event_tx, event_rx) = mpsc::channel(8);
+
+        let relay = tokio::spawn(relay(stream, CONN_ID, tunnel, event_rx));
+
+        event_tx.send(TunnelEvent::Data(b"partial".to_vec())).await.unwrap();
+        event_tx
+            .send(TunnelEvent::Error("target read failed".to_string()))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), relay)
+            .await
+            .expect("relay did not finish")
+            .expect("relay panicked");
+
+        let errored = tokio::task::spawn_blocking(move || app.join().unwrap())
+            .await
+            .unwrap();
+        assert!(errored, "truncated response was handed to the app as a clean EOF");
+    }
+
+    /// The mirror case: the `Error` lands *after* the response completed, so it
+    /// can only be about the upload direction. Resetting the socket then would
+    /// make the app's kernel discard a response it already received in full, so
+    /// the connection must close with the FIN the Close already sent.
+    #[tokio::test]
+    async fn a_server_error_after_close_does_not_destroy_the_response() {
+        const CONN_ID: u32 = 8;
+
+        let payload: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+        let expected = payload.clone();
+
+        let listener = StdListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // The app does not read until released, so the response is still
+        // sitting unread in its receive buffer when the relay tears down -
+        // exactly the bytes a reset would make the kernel throw away.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let app = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let _ = release_rx.recv();
+            let mut got = Vec::new();
+            let result = sock.read_to_end(&mut got);
+            (result.is_ok(), got)
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tunnel = Arc::new(test_tunnel("pw"));
+        let (event_tx, event_rx) = mpsc::channel(8);
+
+        let relay = tokio::spawn(relay(stream, CONN_ID, tunnel, event_rx));
+
+        event_tx.send(TunnelEvent::Data(payload)).await.unwrap();
+        event_tx.send(TunnelEvent::Close).await.unwrap();
+        event_tx
+            .send(TunnelEvent::Error("target write failed".to_string()))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(10), relay)
+            .await
+            .expect("relay did not finish")
+            .expect("relay panicked");
+
+        let _ = release_tx.send(());
+        let (clean, got) = tokio::task::spawn_blocking(move || app.join().unwrap())
+            .await
+            .unwrap();
+        assert!(clean, "a complete response was destroyed by a reset");
+        assert_eq!(got, expected, "response payload was lost");
     }
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -28,6 +28,13 @@ pub async fn relay(
     // Raised by the write half when the connection has failed. The read half
     // has to stop cooperatively rather than being aborted: aborting would drop
     // its socket half, and both halves are needed to abort the connection.
+    //
+    // Only failures raise it. After a clean Close the read half deliberately
+    // stays open: the target closing its output says nothing about the app's
+    // upload, which the server still accepts, so this relay ends when the app
+    // closes its own side. An app that holds a half-closed connection open
+    // forever keeps its conn_id registered - correct for TCP, and bounded in
+    // practice by the app being a local process rather than a remote peer.
     let failed = Arc::new(Notify::new());
     let failed_read = failed.clone();
 
@@ -83,8 +90,11 @@ pub async fn relay(
 
     let failed_notify = failed;
     let write_task = tokio::spawn(async move {
-        // Whether this connection ended in a failure. A truncated stream must
-        // not be handed to the app as a clean end-of-stream.
+        // A clean end-of-stream is only ever earned by an explicit terminal
+        // event. Anything else that ends this loop leaves the response
+        // truncated, and handing that to the app as a successful EOF is the
+        // silent corruption this relay exists to avoid.
+        let mut terminal_seen = false;
         let mut failed = false;
         while let Some(event) = event_rx.recv().await {
             match event {
@@ -95,29 +105,43 @@ pub async fn relay(
                     debug!("[{}] tunnel -> client {} bytes", conn_id, data.len());
                     if let Err(e) = tcp_write.write_all(&data).await {
                         error!("[{}] client write error: {}", conn_id, e);
+                        failed = true;
                         break;
                     }
                 }
                 TunnelEvent::Close => {
                     debug!("[{}] tunnel closed", conn_id);
+                    terminal_seen = true;
                     // Everything arrived: FIN, so the app reads a clean EOF.
                     let _ = tcp_write.shutdown().await;
                     break;
                 }
                 TunnelEvent::Error(msg) => {
                     debug!("[{}] tunnel error: {}", conn_id, msg);
+                    terminal_seen = true;
                     failed = true;
-                    // Release the read half so the connection can be aborted:
-                    // the app is waiting on a response that will never arrive,
-                    // so it will not close its side on its own.
-                    failed_notify.notify_one();
                     break;
                 }
                 TunnelEvent::Exit(_) => {
                     // Only meaningful for remote exec; a TCP relay never sees it.
+                    terminal_seen = true;
                     break;
                 }
             }
+        }
+
+        // The channel was dropped with no terminal event: the server session
+        // was reset, or the dispatcher dropped this connection as stalled.
+        // Either way the response stopped mid-stream.
+        if !terminal_seen {
+            debug!("[{}] dispatch channel dropped mid-stream", conn_id);
+            failed = true;
+        }
+        if failed {
+            // Release the read half so the connection can be aborted: the app
+            // is waiting on a response that will never arrive, so it will not
+            // close its side on its own.
+            failed_notify.notify_one();
         }
         (tcp_write, failed)
     });
@@ -158,5 +182,58 @@ pub async fn relay(
             }
         }
         Err(e) => debug!("[{}] could not reunite socket halves: {}", conn_id, e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tunnel::tests::test_tunnel;
+    use std::io::Read as _;
+    use std::net::TcpListener as StdListener;
+
+    /// The dispatch channel can be dropped without any terminal event: a server
+    /// session Reset clears every channel, and the SSE dispatcher drops a
+    /// connection it considers stalled. The response is truncated either way,
+    /// so the app must not be handed a clean end-of-stream.
+    #[tokio::test]
+    async fn a_dropped_dispatch_channel_is_not_a_clean_eof() {
+        const CONN_ID: u32 = 5;
+
+        // Stand-in for the proxied app, on a blocking socket so we can assert
+        // on exactly what a real client's read would see.
+        let listener = StdListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut got = Vec::new();
+            let result = sock.read_to_end(&mut got);
+            (result.is_err(), got)
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tunnel = Arc::new(test_tunnel("pw"));
+        let (event_tx, event_rx) = mpsc::channel(8);
+
+        let relay = tokio::spawn(relay(stream, CONN_ID, tunnel, event_rx));
+
+        // Part of a response arrives, then the channel goes away mid-stream
+        // with no Close and no Error - exactly what Reset and the stall path do.
+        event_tx.send(TunnelEvent::Data(b"partial".to_vec())).await.unwrap();
+        drop(event_tx);
+
+        tokio::time::timeout(Duration::from_secs(10), relay)
+            .await
+            .expect("relay did not finish")
+            .expect("relay panicked");
+
+        let (errored, got) = tokio::task::spawn_blocking(move || app.join().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            errored,
+            "truncated response was handed to the app as a clean EOF after {} byte(s)",
+            got.len()
+        );
     }
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,7 +1,6 @@
 use crate::tunnel::{Tunnel, TunnelEvent};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, Notify};
@@ -37,17 +36,26 @@ pub async fn relay(
     // practice by the app being a local process rather than a remote peer.
     let failed = Arc::new(Notify::new());
     let failed_read = failed.clone();
+    // Whether that failure was the server's own report. It has then already
+    // released the target writer, so the Close below would be redundant.
+    let server_reported = Arc::new(AtomicBool::new(false));
+    let server_reported_read = server_reported.clone();
+    // Raised by the read half once the upload side is done, so the write half
+    // knows no further failure report can arrive.
+    let upload_done = Arc::new(Notify::new());
+    let upload_done_write = upload_done.clone();
 
     let read_task = tokio::spawn(async move {
         let mut buf = vec![0u8; 32768];
-        let mut give_up = false;
+        // Set when the write half stopped us after the server reported failure.
+        let mut stopped_by_server = false;
         loop {
             let read = tokio::select! {
                 // Cancel-safe: no bytes are consumed if the other branch wins.
                 result = tcp_read.read(&mut buf) => result,
                 _ = failed_read.notified() => {
                     debug!("[{}] connection failed; stopping the upload side", conn_id);
-                    give_up = true;
+                    stopped_by_server = true;
                     break;
                 }
             };
@@ -79,12 +87,20 @@ pub async fn relay(
         // the conn_id here: the target may still be streaming a response, and
         // dropping the dispatch channel now would discard it.
         //
-        // Skipped when the connection failed: the target socket is already gone
-        // and the server has released its writer, so there is nothing to close.
-        if !give_up {
+        // Sent on local failures too, not just clean EOF: only the server can
+        // release the target writer, and when the failure is ours it has heard
+        // nothing — its SSE watchdog cannot help while our stream is still
+        // alive, so without this the writer is held indefinitely. Skipped only
+        // when the server itself reported the failure, having already released
+        // the writer: the POST would be redundant, and on a broken tunnel it
+        // costs a full reconnect wait before failing anyway.
+        if !(stopped_by_server && server_reported_read.load(Ordering::SeqCst)) {
             let close_msg = Message::Close { conn_id };
             let _ = tunnel_clone.send_message(&close_msg).await;
         }
+
+        // Let the write half stop waiting for a late failure report.
+        upload_done.notify_one();
         tcp_read
     });
 
@@ -96,7 +112,25 @@ pub async fn relay(
         // silent corruption this relay exists to avoid.
         let mut terminal_seen = false;
         let mut failed = false;
-        while let Some(event) = event_rx.recv().await {
+        // Set once the response direction has closed cleanly. The upload can
+        // still fail on the target after that, and the server reports it as a
+        // late Error, so this half keeps draining until the upload side is
+        // done rather than exiting on Close and losing that report.
+        let mut response_closed = false;
+        loop {
+            let event = tokio::select! {
+                // Biased so queued events are always drained before the exit
+                // signal wins: a late Error must not be lost to the race.
+                biased;
+                received = event_rx.recv() => match received {
+                    Some(event) => event,
+                    None => break,
+                },
+                _ = upload_done_write.notified(), if response_closed => {
+                    debug!("[{}] upload finished; nothing left to report", conn_id);
+                    break;
+                }
+            };
             match event {
                 TunnelEvent::Data(data) => {
                     if data.is_empty() {
@@ -112,14 +146,17 @@ pub async fn relay(
                 TunnelEvent::Close => {
                     debug!("[{}] tunnel closed", conn_id);
                     terminal_seen = true;
+                    response_closed = true;
                     // Everything arrived: FIN, so the app reads a clean EOF.
+                    // Not breaking here - the upload may still fail, and the
+                    // app has to hear about it.
                     let _ = tcp_write.shutdown().await;
-                    break;
                 }
                 TunnelEvent::Error(msg) => {
                     debug!("[{}] tunnel error: {}", conn_id, msg);
                     terminal_seen = true;
                     failed = true;
+                    server_reported.store(true, Ordering::SeqCst);
                     break;
                 }
                 TunnelEvent::Exit(_) => {
@@ -172,12 +209,11 @@ pub async fn relay(
     };
     match read_half.reunite(write_half) {
         Ok(stream) => {
-            // Deprecated in tokio because a *non-zero* linger blocks the thread
-            // on drop. A zero timeout is the opposite: it makes close() return
-            // immediately and emit RST, which is exactly the signal wanted here.
-            #[allow(deprecated)]
-            let linger = stream.set_linger(Some(Duration::ZERO));
-            if let Err(e) = linger {
+            // Zero linger makes close() return immediately and emit RST, which
+            // is exactly the signal wanted here. (The general set_linger is
+            // deprecated because a *non-zero* timeout blocks the thread on
+            // drop; this dedicated call carries no such warning.)
+            if let Err(e) = stream.set_zero_linger() {
                 debug!("[{}] could not set SO_LINGER, closing with FIN: {}", conn_id, e);
             }
         }
@@ -188,6 +224,7 @@ pub async fn relay(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use crate::tunnel::tests::test_tunnel;
     use std::io::Read as _;
     use std::net::TcpListener as StdListener;
@@ -196,7 +233,10 @@ mod tests {
     /// session Reset clears every channel, and the SSE dispatcher drops a
     /// connection it considers stalled. The response is truncated either way,
     /// so the app must not be handed a clean end-of-stream.
-    #[tokio::test]
+    /// Time is paused: the read half still reports the connection to the
+    /// server on this path, and this test's tunnel has no server behind it, so
+    /// that send spends its full reconnect wait in virtual time.
+    #[tokio::test(start_paused = true)]
     async fn a_dropped_dispatch_channel_is_not_a_clean_eof() {
         const CONN_ID: u32 = 5;
 
@@ -222,7 +262,7 @@ mod tests {
         event_tx.send(TunnelEvent::Data(b"partial".to_vec())).await.unwrap();
         drop(event_tx);
 
-        tokio::time::timeout(Duration::from_secs(10), relay)
+        tokio::time::timeout(Duration::from_secs(600), relay)
             .await
             .expect("relay did not finish")
             .expect("relay panicked");

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -125,10 +125,10 @@ pub async fn relay(
     let failed_notify = failed;
     let write_task = tokio::spawn(async move {
         // A clean end-of-stream is only ever earned by an explicit terminal
-        // event. Anything else that ends this loop leaves the response
-        // truncated, and handing that to the app as a successful EOF is the
+        // event. Anything else that ends this loop leaves the connection
+        // broken, and handing that to the app as a successful EOF is the
         // silent corruption this relay exists to avoid.
-        let mut terminal_seen = false;
+        let mut channel_dropped = false;
         let mut failed = false;
         // Set once the response direction has closed cleanly. The upload can
         // still fail on the target after that, and the server reports it as a
@@ -142,7 +142,10 @@ pub async fn relay(
                 biased;
                 received = event_rx.recv() => match received {
                     Some(event) => event,
-                    None => break,
+                    None => {
+                        channel_dropped = true;
+                        break;
+                    }
                 },
                 _ = upload_done_write.notified(), if response_closed => {
                     debug!("[{}] upload finished; nothing left to report", conn_id);
@@ -163,7 +166,6 @@ pub async fn relay(
                 }
                 TunnelEvent::Close => {
                     debug!("[{}] tunnel closed", conn_id);
-                    terminal_seen = true;
                     response_closed = true;
                     // Everything arrived: FIN, so the app reads a clean EOF.
                     // Not breaking here - the upload may still fail, and the
@@ -172,24 +174,25 @@ pub async fn relay(
                 }
                 TunnelEvent::Error(msg) => {
                     debug!("[{}] tunnel error: {}", conn_id, msg);
-                    terminal_seen = true;
                     failed = true;
                     server_reported.store(true, Ordering::SeqCst);
                     break;
                 }
                 TunnelEvent::Exit(_) => {
                     // Only meaningful for remote exec; a TCP relay never sees it.
-                    terminal_seen = true;
                     break;
                 }
             }
         }
 
-        // The channel was dropped with no terminal event: the server session
-        // was reset, or the dispatcher dropped this connection as stalled.
-        // Either way the response stopped mid-stream.
-        if !terminal_seen {
-            debug!("[{}] dispatch channel dropped mid-stream", conn_id);
+        // The channel was dropped before the upload finished: the server
+        // session was reset, or the dispatcher dropped this connection as
+        // stalled. Before Close that truncates the response. After Close the
+        // response is complete, but the upload still in progress now lands on
+        // a server that no longer knows this conn_id and discards it with a
+        // 200. Both are failures the app has to see, not a clean EOF.
+        if channel_dropped {
+            debug!("[{}] dispatch channel dropped before the connection finished", conn_id);
             failed = true;
         }
         if failed {
@@ -294,5 +297,46 @@ mod tests {
             "truncated response was handed to the app as a clean EOF after {} byte(s)",
             got.len()
         );
+    }
+
+    /// The channel can also be dropped *after* a clean Close, while the app is
+    /// still uploading. The server that reset no longer knows the conn_id, so
+    /// every further chunk is discarded with a 200. The relay must not sit
+    /// waiting for an app that has no reason to stop; it has to fail the
+    /// connection so the app finds out.
+    #[tokio::test]
+    async fn a_dropped_dispatch_channel_after_close_still_fails_the_connection() {
+        const CONN_ID: u32 = 6;
+
+        // Stand-in for the app: it holds its side open, never closing, the way
+        // an upload in progress would.
+        let listener = StdListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let app = std::thread::spawn(move || {
+            let (sock, _) = listener.accept().unwrap();
+            let _ = release_rx.recv();
+            drop(sock);
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let tunnel = Arc::new(test_tunnel("pw"));
+        let (event_tx, event_rx) = mpsc::channel(8);
+
+        let relay = tokio::spawn(relay(stream, CONN_ID, tunnel, event_rx));
+
+        // Response completes cleanly, then the session is reset mid-upload.
+        event_tx.send(TunnelEvent::Data(b"reply".to_vec())).await.unwrap();
+        event_tx.send(TunnelEvent::Close).await.unwrap();
+        drop(event_tx);
+
+        // Without treating the drop as a failure, the read half keeps waiting
+        // for the app's EOF and this never returns.
+        let finished = tokio::time::timeout(Duration::from_secs(10), relay).await;
+        let _ = release_tx.send(());
+        tokio::task::spawn_blocking(move || app.join().unwrap()).await.unwrap();
+        finished
+            .expect("relay kept waiting on the app after its channel was dropped")
+            .expect("relay panicked");
     }
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -49,9 +49,13 @@ pub async fn relay(
                 }
             }
         }
+        // Tell the server we are done sending. It drops the target's write
+        // half, so the target sees a real FIN — the half-close signal some
+        // protocols need to start replying. Deliberately *not* unregistering
+        // the conn_id here: the target may still be streaming a response, and
+        // dropping the dispatch channel now would discard it.
         let close_msg = Message::Close { conn_id };
         let _ = tunnel_clone.send_message(&close_msg).await;
-        tunnel_clone.unregister_connection(conn_id).await;
     });
 
     let write_task = tokio::spawn(async move {
@@ -83,8 +87,12 @@ pub async fn relay(
         }
     });
 
-    tokio::select! {
-        _ = read_task => {},
-        _ = write_task => {},
-    }
+    // Both directions run to completion independently: an upload that finishes
+    // must not cut off a response still in flight, and a target that stops
+    // replying must not cut off an upload still in progress. The read half ends
+    // on client EOF; the write half ends when the server reports the target
+    // closed (Close/Error), the session is reset, or the client socket dies.
+    let (_, _) = tokio::join!(read_task, write_task);
+
+    tunnel.unregister_connection(conn_id).await;
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,9 +1,10 @@
 use crate::tunnel::{Tunnel, TunnelEvent};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 use tracing::{debug, error};
 use crate::protocol::Message;
 
@@ -24,10 +25,26 @@ pub async fn relay(
     let (mut tcp_read, mut tcp_write) = stream.into_split();
     let tunnel_clone = tunnel.clone();
 
+    // Raised by the write half when the connection has failed. The read half
+    // has to stop cooperatively rather than being aborted: aborting would drop
+    // its socket half, and both halves are needed to abort the connection.
+    let failed = Arc::new(Notify::new());
+    let failed_read = failed.clone();
+
     let read_task = tokio::spawn(async move {
         let mut buf = vec![0u8; 32768];
+        let mut give_up = false;
         loop {
-            match tcp_read.read(&mut buf).await {
+            let read = tokio::select! {
+                // Cancel-safe: no bytes are consumed if the other branch wins.
+                result = tcp_read.read(&mut buf) => result,
+                _ = failed_read.notified() => {
+                    debug!("[{}] connection failed; stopping the upload side", conn_id);
+                    give_up = true;
+                    break;
+                }
+            };
+            match read {
                 Ok(0) => {
                     debug!("[{}] client EOF", conn_id);
                     break;
@@ -54,11 +71,21 @@ pub async fn relay(
         // protocols need to start replying. Deliberately *not* unregistering
         // the conn_id here: the target may still be streaming a response, and
         // dropping the dispatch channel now would discard it.
-        let close_msg = Message::Close { conn_id };
-        let _ = tunnel_clone.send_message(&close_msg).await;
+        //
+        // Skipped when the connection failed: the target socket is already gone
+        // and the server has released its writer, so there is nothing to close.
+        if !give_up {
+            let close_msg = Message::Close { conn_id };
+            let _ = tunnel_clone.send_message(&close_msg).await;
+        }
+        tcp_read
     });
 
+    let failed_notify = failed;
     let write_task = tokio::spawn(async move {
+        // Whether this connection ended in a failure. A truncated stream must
+        // not be handed to the app as a clean end-of-stream.
+        let mut failed = false;
         while let Some(event) = event_rx.recv().await {
             match event {
                 TunnelEvent::Data(data) => {
@@ -73,10 +100,17 @@ pub async fn relay(
                 }
                 TunnelEvent::Close => {
                     debug!("[{}] tunnel closed", conn_id);
+                    // Everything arrived: FIN, so the app reads a clean EOF.
+                    let _ = tcp_write.shutdown().await;
                     break;
                 }
                 TunnelEvent::Error(msg) => {
                     debug!("[{}] tunnel error: {}", conn_id, msg);
+                    failed = true;
+                    // Release the read half so the connection can be aborted:
+                    // the app is waiting on a response that will never arrive,
+                    // so it will not close its side on its own.
+                    failed_notify.notify_one();
                     break;
                 }
                 TunnelEvent::Exit(_) => {
@@ -85,14 +119,44 @@ pub async fn relay(
                 }
             }
         }
+        (tcp_write, failed)
     });
 
     // Both directions run to completion independently: an upload that finishes
     // must not cut off a response still in flight, and a target that stops
-    // replying must not cut off an upload still in progress. The read half ends
-    // on client EOF; the write half ends when the server reports the target
-    // closed (Close/Error), the session is reset, or the client socket dies.
-    let (_, _) = tokio::join!(read_task, write_task);
+    // replying must not cut off an upload still in progress.
+    //
+    // On failure the write half signals the read half to stop, so both return
+    // their socket halves and the connection can be aborted below.
+    let (read_half, write_half) = tokio::join!(read_task, write_task);
+    let failed = matches!(&write_half, Ok((_, true)));
 
     tunnel.unregister_connection(conn_id).await;
+
+    // A failed connection has to fail visibly. Dropping the socket sends FIN,
+    // which the app reads as a successful end-of-stream on data that is in fact
+    // truncated. Reuniting the halves and setting SO_LINGER to zero makes the
+    // close a RST instead, so the app's read fails and it cannot mistake the
+    // short stream for a complete one. Reunite consumes both halves, so no FIN
+    // escapes on the way.
+    if !failed {
+        return;
+    }
+    let (Ok(read_half), Ok((write_half, _))) = (read_half, write_half) else {
+        debug!("[{}] relay half did not return its socket; closing with FIN", conn_id);
+        return;
+    };
+    match read_half.reunite(write_half) {
+        Ok(stream) => {
+            // Deprecated in tokio because a *non-zero* linger blocks the thread
+            // on drop. A zero timeout is the opposite: it makes close() return
+            // immediately and emit RST, which is exactly the signal wanted here.
+            #[allow(deprecated)]
+            let linger = stream.set_linger(Some(Duration::ZERO));
+            if let Err(e) = linger {
+                debug!("[{}] could not set SO_LINGER, closing with FIN: {}", conn_id, e);
+            }
+        }
+        Err(e) => debug!("[{}] could not reunite socket halves: {}", conn_id, e),
+    }
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -51,13 +51,18 @@ pub async fn relay(
         let mut stopped_by_server = false;
         loop {
             let read = tokio::select! {
-                // Cancel-safe: no bytes are consumed if the other branch wins.
-                result = tcp_read.read(&mut buf) => result,
+                // Biased toward the failure signal: once the connection has
+                // failed, every further chunk costs another send_message on the
+                // tunnel that just broke, and an unbiased poll can keep picking
+                // the read for as long as the app has bytes buffered.
+                biased;
                 _ = failed_read.notified() => {
                     debug!("[{}] connection failed; stopping the upload side", conn_id);
                     stopped_by_server = true;
                     break;
                 }
+                // Cancel-safe: no bytes are consumed if the other branch wins.
+                result = tcp_read.read(&mut buf) => result,
             };
             match read {
                 Ok(0) => {
@@ -96,7 +101,20 @@ pub async fn relay(
         // costs a full reconnect wait before failing anyway.
         if !(stopped_by_server && server_reported_read.load(Ordering::SeqCst)) {
             let close_msg = Message::Close { conn_id };
-            let _ = tunnel_clone.send_message(&close_msg).await;
+            if stopped_by_server {
+                // This connection is about to be aborted, and the app is
+                // waiting on a response that will never arrive - it has to find
+                // that out now. send_message can spend a full RECONNECT_WAIT on
+                // the very tunnel whose failure got us here, so it must not sit
+                // between the failure and the RST below. The server still needs
+                // the Close to release the target writer, so hand it off rather
+                // than drop it.
+                tokio::spawn(async move {
+                    let _ = tunnel_clone.send_message(&close_msg).await;
+                });
+            } else {
+                let _ = tunnel_clone.send_message(&close_msg).await;
+            }
         }
 
         // Let the write half stop waiting for a late failure report.
@@ -233,10 +251,11 @@ mod tests {
     /// session Reset clears every channel, and the SSE dispatcher drops a
     /// connection it considers stalled. The response is truncated either way,
     /// so the app must not be handed a clean end-of-stream.
-    /// Time is paused: the read half still reports the connection to the
-    /// server on this path, and this test's tunnel has no server behind it, so
-    /// that send spends its full reconnect wait in virtual time.
-    #[tokio::test(start_paused = true)]
+    /// Real time, deliberately: the read half's teardown Close goes out on a
+    /// detached task, so nothing here waits on the tunnel and the relay tears
+    /// down in milliseconds. A paused clock would auto-advance past any timeout
+    /// set here while that Close was doing real (non-timer) network I/O.
+    #[tokio::test]
     async fn a_dropped_dispatch_channel_is_not_a_clean_eof() {
         const CONN_ID: u32 = 5;
 
@@ -262,7 +281,7 @@ mod tests {
         event_tx.send(TunnelEvent::Data(b"partial".to_vec())).await.unwrap();
         drop(event_tx);
 
-        tokio::time::timeout(Duration::from_secs(600), relay)
+        tokio::time::timeout(Duration::from_secs(10), relay)
             .await
             .expect("relay did not finish")
             .expect("relay panicked");

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,9 +1,9 @@
 use crate::tunnel::{Tunnel, TunnelEvent};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error};
 use crate::protocol::Message;
 
@@ -11,6 +11,36 @@ static CONN_COUNTER: AtomicU32 = AtomicU32::new(1);
 
 pub fn next_conn_id() -> u32 {
     CONN_COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+/// How the read half's loop ended.
+enum Upload {
+    /// The app closed its side; nothing more will be sent.
+    Eof,
+    /// The app's socket or the tunnel failed. The connection is dead.
+    Failed,
+    /// The write half stopped us because the connection failed.
+    Stopped(Stop),
+}
+
+/// What the read half tells the write half once the upload side is done.
+enum UploadEnd {
+    /// Clean: the app is finished sending. No failure report can follow from
+    /// this direction, so the write half may exit once the response is closed.
+    Eof,
+    /// The upload side itself broke. The write half must fail the connection
+    /// now rather than wait for a terminal event that cannot arrive.
+    Failed,
+}
+
+/// Why the write half is stopping the read half, so it knows whether the
+/// server still needs to be told.
+enum Stop {
+    /// The server reported the failure itself, so it has already released the
+    /// target.
+    ServerReported,
+    /// The failure is local to this client; the server has heard nothing.
+    Local,
 }
 
 /// Bidirectional relay between a TCP stream and the tunnel.
@@ -24,54 +54,36 @@ pub async fn relay(
     let (mut tcp_read, mut tcp_write) = stream.into_split();
     let tunnel_clone = tunnel.clone();
 
-    // Raised by the write half when the connection has failed. The read half
+    // The two halves coordinate over two one-shot signals, each carrying its
+    // reason, so neither side has to infer state the other already knows.
+    //
+    // Read half -> write half: how the upload side ended. After the app's EOF
+    // the write half deliberately keeps going: the target closing its output
+    // says nothing about the app's upload, and the reverse holds too, so this
+    // relay ends only when *both* directions are done. An app that holds a
+    // half-closed connection open forever keeps its conn_id registered here
+    // and its target socket held on the server - correct for TCP, but note
+    // that neither side applies an idle timeout, so "forever" is literal.
+    let (upload_tx, mut upload_rx) = oneshot::channel::<UploadEnd>();
+    // Write half -> read half: stop, the connection has failed. The read half
     // has to stop cooperatively rather than being aborted: aborting would drop
     // its socket half, and both halves are needed to abort the connection.
-    //
-    // Only failures raise it. After a clean Close the read half deliberately
-    // stays open: the target closing its output says nothing about the app's
-    // upload, which the server still accepts, so this relay ends when the app
-    // closes its own side. An app that holds a half-closed connection open
-    // forever keeps its conn_id registered - correct for TCP, and bounded in
-    // practice by the app being a local process rather than a remote peer.
-    let failed = Arc::new(Notify::new());
-    let failed_read = failed.clone();
-    // Whether that failure was the server's own report. It has then already
-    // released the target writer, so the Close below would be redundant.
-    let server_reported = Arc::new(AtomicBool::new(false));
-    let server_reported_read = server_reported.clone();
-    // Raised by the read half once the upload side is done, so the write half
-    // knows no further failure report can arrive.
-    let upload_done = Arc::new(Notify::new());
-    let upload_done_write = upload_done.clone();
-    // Raised instead when the upload side ended in failure rather than at the
-    // app's EOF. The write half has to hear that unconditionally: a broken
-    // tunnel produces no events at all, so waiting for a terminal one that
-    // cannot arrive would park this relay - and the app with it - indefinitely.
-    let upload_failed = Arc::new(Notify::new());
-    let upload_failed_write = upload_failed.clone();
+    let (stop_tx, mut stop_rx) = oneshot::channel::<Stop>();
 
     let read_task = tokio::spawn(async move {
         let mut buf = vec![0u8; 32768];
-        // Set when the write half stopped us because the connection failed.
-        // Says nothing about *whose* failure it was - `server_reported` is the
-        // flag that means the server reported it.
-        let mut stopped_by_write_half = false;
-        // Set when the upload side itself broke - the app's socket errored, or
-        // the tunnel would not take the chunk. Either way this connection is
-        // dead, as opposed to the app simply being done sending.
-        let mut local_failure = false;
-        loop {
+        let outcome = loop {
             let read = tokio::select! {
-                // Biased toward the failure signal: once the connection has
-                // failed, every further chunk costs another send_message on the
-                // tunnel that just broke, and an unbiased poll can keep picking
-                // the read for as long as the app has bytes buffered.
+                // Biased toward the stop signal: once the connection has
+                // failed, every further chunk costs another send_message on
+                // the tunnel that just broke, and an unbiased poll can keep
+                // picking the read for as long as the app has bytes buffered.
                 biased;
-                _ = failed_read.notified() => {
+                stop = &mut stop_rx => {
                     debug!("[{}] connection failed; stopping the upload side", conn_id);
-                    stopped_by_write_half = true;
-                    break;
+                    // Err means the write half went away without saying why
+                    // (it panicked). The server has heard nothing either way.
+                    break Upload::Stopped(stop.unwrap_or(Stop::Local));
                 }
                 // Cancel-safe: no bytes are consumed if the other branch wins.
                 result = tcp_read.read(&mut buf) => result,
@@ -79,7 +91,7 @@ pub async fn relay(
             match read {
                 Ok(0) => {
                     debug!("[{}] client EOF", conn_id);
-                    break;
+                    break Upload::Eof;
                 }
                 Ok(n) => {
                     debug!("[{}] client -> tunnel {} bytes", conn_id, n);
@@ -89,72 +101,77 @@ pub async fn relay(
                     };
                     if let Err(e) = tunnel_clone.send_message(&msg).await {
                         error!("[{}] tunnel send error: {}", conn_id, e);
-                        local_failure = true;
-                        break;
+                        break Upload::Failed;
                     }
                 }
                 Err(e) => {
                     debug!("[{}] client read error: {}", conn_id, e);
-                    local_failure = true;
-                    break;
+                    break Upload::Failed;
                 }
             }
-        }
-        // Tell the server we are done sending. It drops the target's write
-        // half, so the target sees a real FIN — the half-close signal some
-        // protocols need to start replying. Deliberately *not* unregistering
-        // the conn_id here: the target may still be streaming a response, and
-        // dropping the dispatch channel now would discard it.
-        //
-        // Sent on local failures too, not just clean EOF: only the server can
-        // release the target writer, and when the failure is ours it has heard
-        // nothing — its SSE watchdog cannot help while our stream is still
-        // alive, so without this the writer is held indefinitely. Skipped only
-        // when the server itself reported the failure, having already released
-        // the writer: the POST would be redundant, and on a broken tunnel it
-        // costs a full reconnect wait before failing anyway.
-        let aborting = stopped_by_write_half || local_failure;
-        if !(stopped_by_write_half && server_reported_read.load(Ordering::SeqCst)) {
-            let close_msg = Message::Close { conn_id };
-            if aborting {
-                // This connection is about to be aborted, and the app is
-                // waiting on a response that will never arrive - it has to find
-                // that out now. send_message can spend a full RECONNECT_WAIT on
-                // the very tunnel whose failure got us here, so it must not sit
-                // between the failure and the RST below. The server still needs
-                // the Close to release the target writer, so hand it off rather
-                // than drop it.
+        };
+
+        // Tell the server how this side ended. Deliberately *not*
+        // unregistering the conn_id here: the target may still be streaming a
+        // response, and dropping the dispatch channel now would discard it.
+        match outcome {
+            // The server reported the failure itself, so it has already
+            // released the target. Another POST would be redundant, and on a
+            // broken tunnel it costs a full reconnect wait before failing.
+            Upload::Stopped(Stop::ServerReported) => {}
+            // Close: we are done sending. The server drops the target's write
+            // half, so the target sees a real FIN - the half-close signal some
+            // protocols need to start replying - and keeps its read half, so
+            // the response still flows.
+            Upload::Eof => {
+                let _ = tunnel_clone.send_message(&Message::Close { conn_id }).await;
+            }
+            // Abort: this connection is dead on our side. Close would only
+            // half-close it, and the server would keep pulling the target's
+            // response into a conn_id we are about to unregister - for an
+            // abandoned download, all the way to the end. Abort releases the
+            // target entirely.
+            //
+            // Sent on a detached task: the app is waiting on a response that
+            // will never arrive and has to find that out now, but send_message
+            // can spend a full RECONNECT_WAIT on the very tunnel whose failure
+            // got us here, so it must not sit between the failure and the RST
+            // below. The server still needs to hear it, so hand it off rather
+            // than drop it.
+            Upload::Failed | Upload::Stopped(Stop::Local) => {
                 tokio::spawn(async move {
-                    let _ = tunnel_clone.send_message(&close_msg).await;
+                    let _ = tunnel_clone.send_message(&Message::Abort { conn_id }).await;
                 });
-            } else {
-                let _ = tunnel_clone.send_message(&close_msg).await;
             }
         }
 
-        // Let the write half stop waiting: cleanly if the app just finished
-        // sending, as a failure if the upload broke.
-        if local_failure {
-            upload_failed.notify_one();
-        } else {
-            upload_done.notify_one();
-        }
+        // Let the write half stop waiting. Only a failure of the upload side
+        // itself is reported as one: a stop came *from* the write half, which
+        // is already gone.
+        let _ = upload_tx.send(match outcome {
+            Upload::Failed => UploadEnd::Failed,
+            Upload::Eof | Upload::Stopped(_) => UploadEnd::Eof,
+        });
         tcp_read
     });
 
-    let failed_notify = failed;
     let write_task = tokio::spawn(async move {
         // A clean end-of-stream is only ever earned by an explicit terminal
         // event. Anything else that ends this loop leaves the connection
         // broken, and handing that to the app as a successful EOF is the
         // silent corruption this relay exists to avoid.
-        let mut channel_dropped = false;
         let mut failed = false;
+        // Whether that failure was the server's own report: it has then
+        // already released the target, and the read half need not tell it.
+        let mut server_reported = false;
         // Set once the response direction has closed cleanly. The upload can
         // still fail on the target after that, and the server reports it as a
         // late Error, so this half keeps draining until the upload side is
         // done rather than exiting on Close and losing that report.
         let mut response_closed = false;
+        // Set once the read half has reported the upload's end. Its one-shot
+        // is consumed at that point, so this also retires its select branch.
+        let mut upload_ended = false;
         loop {
             let event = tokio::select! {
                 // Biased so queued events are always drained before the exit
@@ -163,18 +180,40 @@ pub async fn relay(
                 received = event_rx.recv() => match received {
                     Some(event) => event,
                     None => {
-                        channel_dropped = true;
+                        // The server session was reset, or the dispatcher
+                        // dropped this connection as stalled. Before Close
+                        // that truncates the response. After Close the
+                        // response is complete, but an upload still in
+                        // progress now lands on a server that no longer knows
+                        // this conn_id and discards it with a 200 - so the
+                        // upload has to stop, even though the response
+                        // direction was fine.
+                        debug!("[{}] dispatch channel dropped before the connection finished", conn_id);
+                        failed = true;
                         break;
                     }
                 },
-                _ = upload_failed_write.notified() => {
-                    debug!("[{}] upload side failed; failing the connection", conn_id);
-                    failed = true;
-                    break;
-                }
-                _ = upload_done_write.notified(), if response_closed => {
-                    debug!("[{}] upload finished; nothing left to report", conn_id);
-                    break;
+                upload = &mut upload_rx, if !upload_ended => {
+                    upload_ended = true;
+                    match upload {
+                        Ok(UploadEnd::Eof) if response_closed => {
+                            debug!("[{}] upload finished; nothing left to report", conn_id);
+                            break;
+                        }
+                        // The response is still open: keep draining it. No
+                        // failure report can follow from the upload side now.
+                        Ok(UploadEnd::Eof) => continue,
+                        // The upload side broke - or the read half is gone
+                        // without a report, which is a panic. A broken tunnel
+                        // produces no events at all, so waiting for a terminal
+                        // one that cannot arrive would park this relay, and
+                        // the app with it, indefinitely.
+                        Ok(UploadEnd::Failed) | Err(_) => {
+                            debug!("[{}] upload side failed; failing the connection", conn_id);
+                            failed = true;
+                            break;
+                        }
+                    }
                 }
             };
             match event {
@@ -193,39 +232,37 @@ pub async fn relay(
                     debug!("[{}] tunnel closed", conn_id);
                     response_closed = true;
                     // Everything arrived: FIN, so the app reads a clean EOF.
-                    // Not breaking here - the upload may still fail, and the
-                    // app has to hear about it.
                     let _ = tcp_write.shutdown().await;
+                    // Not done yet unless the upload side already is - it may
+                    // still fail on the target, and the app has to hear about
+                    // it.
+                    if upload_ended {
+                        break;
+                    }
                 }
                 TunnelEvent::Error(msg) => {
                     debug!("[{}] tunnel error: {}", conn_id, msg);
                     failed = true;
-                    server_reported.store(true, Ordering::SeqCst);
+                    server_reported = true;
                     break;
                 }
                 TunnelEvent::Exit(_) => {
-                    // Only meaningful for remote exec; a TCP relay never sees it.
+                    // Only meaningful for remote exec; a TCP relay never sees
+                    // it. If one arrives anyway the response direction has
+                    // ended without a Close, so fail the connection rather
+                    // than leave the read half parked with nothing to stop it.
+                    debug!("[{}] unexpected exit status on a TCP relay", conn_id);
+                    failed = true;
                     break;
                 }
             }
         }
 
-        // The channel was dropped before the upload finished: the server
-        // session was reset, or the dispatcher dropped this connection as
-        // stalled. Before Close that truncates the response, and the app must
-        // not read it as a successful end-of-stream. After Close the response
-        // is complete, but an upload still in progress now lands on a server
-        // that no longer knows this conn_id and discards it with a 200 - so the
-        // upload has to stop, even though the response direction was fine.
-        if channel_dropped {
-            debug!("[{}] dispatch channel dropped before the connection finished", conn_id);
-            failed = true;
-        }
         if failed {
             // Release the read half so the connection can be aborted: the app
             // is waiting on a response that will never arrive, so it will not
             // close its side on its own.
-            failed_notify.notify_one();
+            let _ = stop_tx.send(if server_reported { Stop::ServerReported } else { Stop::Local });
         }
         // Abort only when the response was *not* already delivered in full.
         // Once Close has been forwarded the app has every byte and a FIN;

--- a/src/server.rs
+++ b/src/server.rs
@@ -961,35 +961,13 @@ async fn relay_pty_connection(
         Message::ExitStatus { conn_id, code },
         Message::Close { conn_id },
     ] {
-        if let Ok(bytes) = msg.to_bytes() {
-            if let Ok(encrypted) = crypto.encrypt(&bytes) {
-                let mut sent = false;
-                // The client is already known gone (writer closed or SSE dead
-                // ≥6s past the reconnect window), so don't spin the full 5s
-                // reconnect retry — one best-effort attempt is enough.
-                let max_retries = if client_gone { 1 } else { 50 };
-                for _ in 0..max_retries {
-                    let sse_tx = {
-                        let sess = session.lock().await;
-                        sess.sse_tx.clone()
-                    };
-                    // Bound each send: a half-open client keeps the old bounded
-                    // channel's receiver alive-but-undrained, so send() would
-                    // park forever and defeat the re-fetch above. On timeout,
-                    // fall through to re-lock and pick up a reconnected sender.
-                    if tokio::time::timeout(Duration::from_millis(500), sse_tx.send(encrypted.clone()))
-                        .await
-                        .is_ok_and(|r| r.is_ok())
-                    {
-                        sent = true;
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-                if !sent && !client_gone {
-                    error!("[{}] failed to deliver shutdown message", conn_id);
-                }
-            }
+        // When the client is already known gone (writer closed, or SSE dead
+        // ≥6s past the reconnect window) one best-effort attempt is enough:
+        // spending the full budget only delays teardown to rediscover that.
+        let attempts = if client_gone { 1 } else { SEND_ATTEMPTS };
+        let sent = send_to_client_with_attempts(conn_id, &msg, &crypto, &session, attempts).await;
+        if !sent && !client_gone {
+            error!("[{}] failed to deliver shutdown message", conn_id);
         }
     }
 
@@ -1065,6 +1043,25 @@ async fn await_sse_dead(session: Arc<Mutex<Session>>) {
 /// client from reading the SSE socket; if the two were the same magnitude, that
 /// stall alone would exhaust this budget and tear down healthy connections.
 async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &Arc<Mutex<Session>>) -> bool {
+    send_to_client_with_attempts(conn_id, msg, crypto, session, SEND_ATTEMPTS).await
+}
+
+/// Delivery attempts `send_to_client` spends before declaring a client
+/// unreachable. See the note on that function for why the resulting budget has
+/// to stay well above the client's `DISPATCH_STALL_TIMEOUT`.
+const SEND_ATTEMPTS: u32 = 50;
+
+/// `send_to_client` with an explicit attempt budget. Only teardown paths that
+/// already know the client is gone should pass anything but `SEND_ATTEMPTS`:
+/// one best-effort attempt still gets the message out if the client happens to
+/// be reachable, without spending the full budget discovering it is not.
+async fn send_to_client_with_attempts(
+    conn_id: u32,
+    msg: &Message,
+    crypto: &Crypto,
+    session: &Arc<Mutex<Session>>,
+    attempts: u32,
+) -> bool {
     let bytes = match msg.to_bytes() {
         Ok(b) => b,
         Err(e) => { error!("[{}] serialize: {}", conn_id, e); return false; }
@@ -1073,7 +1070,7 @@ async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &
         Ok(e) => e,
         Err(e) => { error!("[{}] encrypt: {}", conn_id, e); return false; }
     };
-    for _ in 0..50 {
+    for _ in 0..attempts {
         let sse_tx = {
             let sess = session.lock().await;
             sess.sse_tx.clone()

--- a/src/server.rs
+++ b/src/server.rs
@@ -653,6 +653,16 @@ async fn relay_tcp_connection(
             // No further uploads can arrive, so drop the writer to keep
             // teardown bounded: the write task ends once its sender is gone.
             session_clone.lock().await.tcp_writers.remove(&conn_id);
+            // The client is known unreachable, so spend one attempt, not the
+            // full budget (as the PTY teardown does). It still matters: a
+            // client that has just reconnected would otherwise never hear
+            // that this connection died, and its relay would sit until the
+            // proxied app gave up on its own.
+            let msg = Message::Error {
+                conn_id: Some(conn_id),
+                message: "client unreachable; target relay abandoned".to_string(),
+            };
+            let _ = send_to_client_with_attempts(conn_id, &msg, &crypto_clone, &session_clone, 1).await;
         } else {
             // A target that failed mid-response must not be reported the same
             // way as one that finished: Close means "everything arrived", and
@@ -676,12 +686,20 @@ async fn relay_tcp_connection(
             // The client's relay ends its response direction on this message,
             // so it has to arrive: retry across a reconnect instead of making a
             // single attempt that a momentarily-full queue would defeat.
-            let _ = send_to_client(conn_id, &terminal, &crypto_clone, &session_clone).await;
-            // Deliberately keeping the writer registered: the target closing
-            // its output says nothing about the client's upload, which may
-            // still be in flight. handle_send drops the writer when the
-            // client's own Close arrives, and that is what shuts the target's
-            // write side down.
+            if send_to_client(conn_id, &terminal, &crypto_clone, &session_clone).await {
+                // Deliberately keeping the writer registered: the target
+                // closing its output says nothing about the client's upload,
+                // which may still be in flight. handle_send drops the writer
+                // when the client's own Close arrives, and that is what shuts
+                // the target's write side down.
+            } else {
+                // The client exhausted the delivery budget, so its Close is
+                // not coming either. Release the writer now instead of leaving
+                // the write task to wait on the SSE watchdog, which never
+                // fires for a client whose stream is open but wedged.
+                debug!("[{}] SSE unreachable after target EOF; releasing target writer", conn_id);
+                session_clone.lock().await.tcp_writers.remove(&conn_id);
+            }
         }
     });
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -599,6 +599,8 @@ async fn relay_tcp_connection(
         // Set once a delivery has exhausted its retries: the client is then
         // known unreachable, so teardown shouldn't spend another full budget.
         let mut client_gone = false;
+        // Set when the target itself failed, as opposed to closing cleanly.
+        let mut read_failure: Option<String> = None;
         loop {
             match tcp_read.read(&mut buf).await {
                 Ok(0) => {
@@ -625,6 +627,7 @@ async fn relay_tcp_connection(
                 }
                 Err(e) => {
                     debug!("[{}] TCP read error: {}", conn_id, e);
+                    read_failure = Some(e.to_string());
                     break;
                 }
             }
@@ -635,10 +638,29 @@ async fn relay_tcp_connection(
             // teardown bounded: the write task ends once its sender is gone.
             session_clone.lock().await.tcp_writers.remove(&conn_id);
         } else {
-            // The client's relay ends its response direction on this Close, so
-            // it has to arrive: retry across a reconnect instead of making a
+            // A target that failed mid-response must not be reported the same
+            // way as one that finished: Close means "everything arrived", and
+            // the client turns it into a clean EOF for the proxied app. Error
+            // says the stream is truncated, so the app is failed instead of
+            // being handed a short read that looks complete.
+            let terminal = match read_failure {
+                Some(message) => {
+                    // A failed target socket cannot accept an upload either, so
+                    // release its writer instead of holding it for a Close that
+                    // is no longer coming: the client aborts this connection
+                    // rather than finishing its side.
+                    session_clone.lock().await.tcp_writers.remove(&conn_id);
+                    Message::Error {
+                        conn_id: Some(conn_id),
+                        message: format!("target read failed: {}", message),
+                    }
+                }
+                None => Message::Close { conn_id },
+            };
+            // The client's relay ends its response direction on this message,
+            // so it has to arrive: retry across a reconnect instead of making a
             // single attempt that a momentarily-full queue would defeat.
-            let _ = send_to_client(conn_id, &Message::Close { conn_id }, &crypto_clone, &session_clone).await;
+            let _ = send_to_client(conn_id, &terminal, &crypto_clone, &session_clone).await;
             // Deliberately keeping the writer registered: the target closing
             // its output says nothing about the client's upload, which may
             // still be in flight. handle_send drops the writer when the

--- a/src/server.rs
+++ b/src/server.rs
@@ -594,7 +594,12 @@ async fn relay_tcp_connection(
 ) {
     let crypto_clone = crypto.clone();
     let session_clone = session.clone();
+    // Resolves once the read task has ended, however it ended: the sender is
+    // moved into that task, so a panic drops it too. The write side uses it to
+    // hold off starting its own watchdog - see there.
+    let (read_done_tx, read_done_rx) = tokio::sync::oneshot::channel::<()>();
     let read_task = tokio::spawn(async move {
+        let _read_done = read_done_tx;
         let mut buf = vec![0u8; 32768];
         // Set once a delivery has exhausted its retries: the client is then
         // known unreachable, so teardown shouldn't spend another full budget.
@@ -704,12 +709,27 @@ async fn relay_tcp_connection(
     });
 
     let session_watch = session.clone();
+    let session_dead = session.clone();
     let write_task = tokio::spawn(async move {
         // The writer now outlives target-output EOF, so nothing else would wake
         // this task if the client vanished without sending Close. Bound the
-        // wait on the client the same way the PTY relay does. Pinned once, like
-        // the PTY relay: the counter resets itself whenever the stream is live.
-        let sse_dead = await_sse_dead(session_watch.clone());
+        // wait on the client the same way the PTY relay does.
+        //
+        // Deliberately not started until the read task is gone. While both
+        // halves are live, that task's own watchdog (and its failing
+        // deliveries) already cover a vanished client: every one of those paths
+        // removes this writer, which ends this task through `recv()`. Only once
+        // the read task has finished - having kept the writer registered past
+        // target-output EOF - is there nothing left to wake us. So one watchdog
+        // timer runs per connection instead of two, and until then this future
+        // is parked on a channel rather than ticking. Awaiting the sender's
+        // *drop* rather than a value covers a read task that panicked.
+        let sse_dead = async move {
+            let _ = read_done_rx.await;
+            // Pinned by the caller below: the counter resets itself whenever
+            // the stream is live.
+            await_sse_dead(session_dead).await;
+        };
         tokio::pin!(sse_dead);
         loop {
             let data = tokio::select! {
@@ -984,8 +1004,15 @@ async fn relay_pty_connection(
         // spending the full budget only delays teardown to rediscover that.
         let attempts = if client_gone { 1 } else { SEND_ATTEMPTS };
         let sent = send_to_client_with_attempts(conn_id, &msg, &crypto, &session, attempts).await;
-        if !sent && !client_gone {
-            error!("[{}] failed to deliver shutdown message", conn_id);
+        if !sent {
+            if !client_gone {
+                error!("[{}] failed to deliver shutdown message", conn_id);
+            }
+            // Stop at the first failure, as relay_pull and relay_push do: a
+            // false return means the client is unreachable, so spending a
+            // second full budget on the Close only delays teardown to
+            // rediscover that.
+            break;
         }
     }
 
@@ -1354,6 +1381,87 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(600), relay)
             .await
             .expect("relay never finished: the write side parked on a dead client")
+            .expect("relay task panicked");
+
+        assert!(
+            !session.lock().await.tcp_writers.contains_key(&CONN_ID),
+            "writer should have been cleaned up after teardown"
+        );
+    }
+
+    /// The write side's watchdog is deliberately not started until the read
+    /// task has gone, so this covers the one case that actually depends on it:
+    /// the target closes its output cleanly, the terminal `Close` is delivered,
+    /// and the writer is kept registered so an upload could still finish. The
+    /// read task is then finished and nothing else can wake this half, so only
+    /// the watchdog can end it once the client vanishes. Time is paused, so the
+    /// grace period elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn write_side_watchdog_starts_after_the_read_task_keeps_the_writer() {
+        const CONN_ID: u32 = 46;
+
+        // Target that closes its output immediately: a clean EOF, not a failure,
+        // so the read task sends Close and keeps the writer.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = target.accept().await {
+                drop(sock);
+            }
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // Healthy client to begin with, so the terminal Close is delivered and
+        // the writer is deliberately left registered.
+        let (sse_tx, mut sse_rx) = mpsc::channel::<Vec<u8>>(16);
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+        session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
+
+        let relay = tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            session.clone(),
+            crypto.clone(),
+        ));
+
+        // Wait for the Close: past this point the read task has finished and
+        // has left the writer in place, so the write half is parked with
+        // nothing but its watchdog left to end it.
+        let queued = tokio::time::timeout(Duration::from_secs(60), sse_rx.recv())
+            .await
+            .expect("terminal Close never arrived")
+            .expect("SSE channel closed before the Close arrived");
+        let decrypted = crypto.decrypt(&queued).unwrap();
+        match Message::from_bytes(&decrypted).unwrap() {
+            Message::Close { conn_id } => assert_eq!(conn_id, CONN_ID),
+            other => panic!("expected Close, got {:?}", other),
+        }
+        assert!(
+            session.lock().await.tcp_writers.contains_key(&CONN_ID),
+            "the writer should outlive target-output EOF so an upload can finish"
+        );
+
+        // Now the client vanishes.
+        drop(sse_rx);
+
+        tokio::time::timeout(Duration::from_secs(600), relay)
+            .await
+            .expect("write side parked: its watchdog never started after the read task ended")
             .expect("relay task panicked");
 
         assert!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -596,6 +596,9 @@ async fn relay_tcp_connection(
     let session_clone = session.clone();
     let read_task = tokio::spawn(async move {
         let mut buf = vec![0u8; 32768];
+        // Set once a delivery has exhausted its retries: the client is then
+        // known unreachable, so teardown shouldn't spend another full budget.
+        let mut client_gone = false;
         loop {
             match tcp_read.read(&mut buf).await {
                 Ok(0) => {
@@ -608,38 +611,15 @@ async fn relay_tcp_connection(
                         conn_id,
                         data: buf[..n].to_vec(),
                     };
-                    let bytes = match msg.to_bytes() {
-                        Ok(b) => b,
-                        Err(e) => { error!("[{}] Serialize: {}", conn_id, e); break; }
-                    };
-                    let encrypted = match crypto_clone.encrypt(&bytes) {
-                        Ok(e) => e,
-                        Err(e) => { error!("[{}] Encrypt: {}", conn_id, e); break; }
-                    };
-
-                    // Deliver this chunk to the (possibly reconnected) SSE
-                    // client, retrying across a reconnect. Never drop it: a gap
-                    // would corrupt the proxied TCP byte stream. Each send is
-                    // timeout-bounded so a half-open client (channel full but
-                    // undrained) can't park us forever; if it stays unreachable,
-                    // close the relay cleanly rather than skip bytes.
-                    let mut delivered = false;
-                    for _ in 0..50 {
-                        let sse_tx = {
-                            let sess = session_clone.lock().await;
-                            sess.sse_tx.clone()
-                        };
-                        if tokio::time::timeout(Duration::from_millis(500), sse_tx.send(encrypted.clone()))
-                            .await
-                            .is_ok_and(|r| r.is_ok())
-                        {
-                            delivered = true;
-                            break;
-                        }
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    if !delivered {
+                    // Never drop a chunk: a gap would corrupt the proxied TCP
+                    // byte stream. send_to_client retries across a client
+                    // reconnect and bounds each attempt, so a half-open client
+                    // (channel full but undrained) can't park us forever. If it
+                    // stays unreachable, close the relay cleanly rather than
+                    // skip bytes.
+                    if !send_to_client(conn_id, &msg, &crypto_clone, &session_clone).await {
                         debug!("[{}] SSE unreachable; closing TCP relay", conn_id);
+                        client_gone = true;
                         break;
                     }
                 }
@@ -650,17 +630,11 @@ async fn relay_tcp_connection(
             }
         }
 
-        let close = Message::Close { conn_id };
-        if let Ok(bytes) = close.to_bytes() {
-            if let Ok(encrypted) = crypto_clone.encrypt(&bytes) {
-                let sse_tx = {
-                    let sess = session_clone.lock().await;
-                    sess.sse_tx.clone()
-                };
-                // Best-effort Close; bound it so a half-open client can't hang
-                // teardown on the full-but-undrained bounded channel.
-                let _ = tokio::time::timeout(Duration::from_millis(500), sse_tx.send(encrypted)).await;
-            }
+        // The client's relay ends its response direction on this Close, so it
+        // has to arrive: retry across a reconnect instead of making a single
+        // attempt that a momentarily-full queue would defeat.
+        if !client_gone {
+            let _ = send_to_client(conn_id, &Message::Close { conn_id }, &crypto_clone, &session_clone).await;
         }
         let mut sess = session_clone.lock().await;
         sess.tcp_writers.remove(&conn_id);
@@ -742,23 +716,19 @@ async fn relay_pty_connection(
         Ok(pair) => pair,
         Err(e) => {
             error!("[{}] PTY async setup failed: {}", conn_id, e);
-            let sse_tx = {
+            {
                 let mut sess = session.lock().await;
                 sess.tcp_writers.remove(&conn_id);
                 sess.pty_resize.remove(&conn_id);
-                sess.sse_tx.clone()
-            };
+            }
+            // Terminal Error: without it the client waits on a PTY that will
+            // never produce output, so retry across a reconnect rather than
+            // losing it to a momentarily-full queue.
             let msg = Message::Error {
                 conn_id: Some(conn_id),
                 message: format!("PTY setup failed: {}", e),
             };
-            if let Ok(bytes) = msg.to_bytes() {
-                if let Ok(encrypted) = crypto.encrypt(&bytes) {
-                    // Best-effort error report; bound it so a half-open client
-                    // can't hang on the full-but-undrained bounded channel.
-                    let _ = tokio::time::timeout(Duration::from_millis(500), sse_tx.send(encrypted)).await;
-                }
-            }
+            let _ = send_to_client(conn_id, &msg, &crypto, &session).await;
             return;
         }
     };
@@ -1011,15 +981,18 @@ async fn forward_pty_chunk(
 
 /// Encrypt `msg` and push it to the (possibly-reconnected) SSE sender, retrying
 /// briefly across a client reconnect. Returns false if it could not be
-/// delivered. Cross-platform sibling of `forward_pty_chunk`, used by transfers.
+/// delivered. Cross-platform sibling of `forward_pty_chunk`; used by TCP
+/// relays, PTY teardown and transfers. Terminal messages (`Close`, `Error`,
+/// `ExitStatus`) must go through here: a single send loses them whenever the
+/// client's queue is momentarily full or its SSE stream is being replaced.
 async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &Arc<Mutex<Session>>) -> bool {
     let bytes = match msg.to_bytes() {
         Ok(b) => b,
-        Err(e) => { error!("[{}] transfer serialize: {}", conn_id, e); return false; }
+        Err(e) => { error!("[{}] serialize: {}", conn_id, e); return false; }
     };
     let encrypted = match crypto.encrypt(&bytes) {
         Ok(e) => e,
-        Err(e) => { error!("[{}] transfer encrypt: {}", conn_id, e); return false; }
+        Err(e) => { error!("[{}] encrypt: {}", conn_id, e); return false; }
     };
     for _ in 0..50 {
         let sse_tx = {
@@ -1164,6 +1137,135 @@ async fn relay_push(
                 &session,
             )
             .await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A terminal `Close` must survive an SSE queue that is momentarily full.
+    /// The relay used to make a single 500ms attempt and give up, so a client
+    /// that stalled (or was mid-reconnect) never learned the target closed and
+    /// its relay was left waiting forever.
+    #[tokio::test]
+    async fn terminal_close_survives_full_sse_queue() {
+        const CONN_ID: u32 = 42;
+
+        // Target that accepts and immediately closes: the relay's read half
+        // sees EOF straight away and heads for the terminal Close.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = target.accept().await {
+                drop(sock);
+            }
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // Capacity-1 SSE channel, pre-filled so the queue is full and undrained.
+        let (sse_tx, mut sse_rx) = mpsc::channel::<Vec<u8>>(1);
+        sse_tx.send(b"already queued".to_vec()).await.unwrap();
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+
+        // Keep the writer alive so only the read half drives teardown.
+        let (_write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+
+        tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            session.clone(),
+            crypto.clone(),
+        ));
+
+        // Stay full well past the old 500ms single-shot budget, then drain.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert_eq!(sse_rx.recv().await.unwrap(), b"already queued".to_vec());
+
+        let queued = tokio::time::timeout(Duration::from_secs(10), sse_rx.recv())
+            .await
+            .expect("terminal Close was dropped instead of retried")
+            .expect("SSE channel closed before the Close arrived");
+
+        let decrypted = crypto.decrypt(&queued).unwrap();
+        match Message::from_bytes(&decrypted).unwrap() {
+            Message::Close { conn_id } => assert_eq!(conn_id, CONN_ID),
+            other => panic!("expected Close, got {:?}", other),
+        }
+    }
+
+    /// A terminal `Close` must follow the client across an SSE reconnect. The
+    /// relay used to snapshot `sse_tx` once, so a Close racing a reconnect went
+    /// into the replaced channel and was never seen on the live one.
+    #[tokio::test]
+    async fn terminal_close_follows_replaced_sse_channel() {
+        const CONN_ID: u32 = 43;
+
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = target.accept().await {
+                drop(sock);
+            }
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // The "old" stream: full and undrained, as a stalled client leaves it.
+        let (old_tx, _old_rx) = mpsc::channel::<Vec<u8>>(1);
+        old_tx.send(b"stale".to_vec()).await.unwrap();
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx: old_tx,
+        }));
+
+        let (_write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+
+        tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            session.clone(),
+            crypto.clone(),
+        ));
+
+        // Client reconnects: handle_stream swaps in a fresh channel while the
+        // relay is still trying to deliver its Close to the old one.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let (new_tx, mut new_rx) = mpsc::channel::<Vec<u8>>(16);
+        session.lock().await.sse_tx = new_tx;
+
+        let queued = tokio::time::timeout(Duration::from_secs(10), new_rx.recv())
+            .await
+            .expect("terminal Close never reached the reconnected stream")
+            .expect("SSE channel closed before the Close arrived");
+
+        let decrypted = crypto.decrypt(&queued).unwrap();
+        match Message::from_bytes(&decrypted).unwrap() {
+            Message::Close { conn_id } => assert_eq!(conn_id, CONN_ID),
+            other => panic!("expected Close, got {:?}", other),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1099,7 +1099,7 @@ async fn send_to_client_with_attempts(
         Ok(e) => e,
         Err(e) => { error!("[{}] encrypt: {}", conn_id, e); return false; }
     };
-    for _ in 0..attempts {
+    for attempt in 0..attempts {
         let sse_tx = {
             let sess = session.lock().await;
             sess.sse_tx.clone()
@@ -1113,7 +1113,12 @@ async fn send_to_client_with_attempts(
         {
             return true;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Space out retries only when there is another one coming: a caller
+        // that already knows the client is gone spends one attempt, and should
+        // not pay a backoff on its way to giving up.
+        if attempt + 1 < attempts {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
     false
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, Notify};
 use tracing::{debug, error, info, warn};
 use crate::archive::{spawn_compress, spawn_decompress};
 use crate::crypto::Crypto;
@@ -31,6 +31,12 @@ struct Session {
     /// Per-conn_id sink for client→target bytes. Covers both TCP connections and
     /// PTYs (remote exec) — a PTY is just another duplex byte stream.
     tcp_writers: HashMap<u32, mpsc::Sender<Vec<u8>>>,
+    /// Per-conn_id abort signal for TCP relays. `Message::Abort` fires it so
+    /// the relay stops pulling the target: `Close` only half-closes the upload
+    /// direction, and an abandoned download would otherwise be pulled to
+    /// completion into a conn_id the client has already forgotten. Only TCP
+    /// connections register one; PTYs and transfers have their own teardown.
+    aborts: HashMap<u32, Arc<Notify>>,
     /// Per-conn_id resize request channel for remote-exec PTYs. Senders are
     /// kept in the session so Message::Resize can deliver a new PtySize
     /// without taking the master PTY out of `relay_pty_connection`.
@@ -203,6 +209,7 @@ async fn handle_stream(session_id: &str, state: &ServerState) -> Response<BoxBod
             .or_insert_with(|| {
                 Arc::new(Mutex::new(Session {
                     tcp_writers: HashMap::new(),
+                    aborts: HashMap::new(),
                     #[cfg(unix)]
                     pty_resize: HashMap::new(),
                     sse_tx: sse_tx.clone(),
@@ -339,15 +346,17 @@ async fn handle_send(
                     let (tcp_read, tcp_write) = tcp_stream.into_split();
 
                     let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(256);
+                    let abort = Arc::new(Notify::new());
                     {
                         let mut sess = session.lock().await;
                         sess.tcp_writers.insert(conn_id, write_tx);
+                        sess.aborts.insert(conn_id, abort.clone());
                     };
 
                     let crypto = hot.crypto.clone();
                     tokio::spawn(async move {
                         relay_tcp_connection(
-                            conn_id, &host, port, tcp_read, tcp_write, write_rx,
+                            conn_id, &host, port, tcp_read, tcp_write, write_rx, abort,
                             session, crypto,
                         )
                         .await;
@@ -390,6 +399,19 @@ async fn handle_send(
             info!("[{}] CLOSE", conn_id);
             let mut sess = session.lock().await;
             sess.tcp_writers.remove(&conn_id);
+            ok_response("")
+        }
+        Message::Abort { conn_id } => {
+            info!("[{}] ABORT", conn_id);
+            // The connection is dead on the client's side. Unlike Close this
+            // releases both directions: the writer so the upload side ends,
+            // and the abort signal so the read task stops pulling the target
+            // instead of streaming the rest of its response to nobody.
+            let mut sess = session.lock().await;
+            sess.tcp_writers.remove(&conn_id);
+            if let Some(abort) = sess.aborts.remove(&conn_id) {
+                abort.notify_one();
+            }
             ok_response("")
         }
         #[cfg(unix)]
@@ -589,6 +611,7 @@ async fn relay_tcp_connection(
     mut tcp_read: tokio::net::tcp::OwnedReadHalf,
     mut tcp_write: tokio::net::tcp::OwnedWriteHalf,
     mut write_rx: mpsc::Receiver<Vec<u8>>,
+    abort: Arc<Notify>,
     session: Arc<Mutex<Session>>,
     crypto: Arc<Crypto>,
 ) {
@@ -606,6 +629,10 @@ async fn relay_tcp_connection(
         let mut client_gone = false;
         // Set when the target itself failed, as opposed to closing cleanly.
         let mut read_failure: Option<String> = None;
+        // Set when the client sent Abort: the connection is dead on its side
+        // and it has already unregistered the conn_id, so there is nobody to
+        // report to and nothing left to relay.
+        let mut aborted = false;
         // A silent target gives this task nothing to react to, so a vanished
         // client would otherwise leave it blocked on read() forever, holding
         // the target socket. The delivery retries below only notice a dead
@@ -617,6 +644,11 @@ async fn relay_tcp_connection(
             let read = tokio::select! {
                 // Cancel-safe: no bytes are consumed if the other branch wins.
                 result = tcp_read.read(&mut buf) => result,
+                _ = abort.notified() => {
+                    debug!("[{}] client aborted; releasing the target", conn_id);
+                    aborted = true;
+                    break;
+                }
                 _ = &mut sse_dead => {
                     debug!("[{}] SSE closed continuously; abandoning target read", conn_id);
                     client_gone = true;
@@ -654,7 +686,13 @@ async fn relay_tcp_connection(
             }
         }
 
-        if client_gone {
+        if aborted {
+            // handle_send already removed the writer, so the write task is
+            // ending on its own. Nothing to send: the client is not listening
+            // for this conn_id any more. Idempotent in case of a race with the
+            // final cleanup below.
+            session_clone.lock().await.tcp_writers.remove(&conn_id);
+        } else if client_gone {
             // No further uploads can arrive, so drop the writer to keep
             // teardown bounded: the write task ends once its sender is gone.
             session_clone.lock().await.tcp_writers.remove(&conn_id);
@@ -772,8 +810,13 @@ async fn relay_tcp_connection(
 
     // Idempotent: the normal paths already removed the writer (client Close, or
     // the client-gone branch above). This catches a target write error, which
-    // ends the write task with the entry still registered.
-    session.lock().await.tcp_writers.remove(&conn_id);
+    // ends the write task with the entry still registered. The abort signal
+    // goes too; nothing can fire it usefully once the relay is gone.
+    {
+        let mut sess = session.lock().await;
+        sess.tcp_writers.remove(&conn_id);
+        sess.aborts.remove(&conn_id);
+    }
 
     info!("[{}] Connection closed for {}:{}", conn_id, host, port);
 }
@@ -1295,6 +1338,7 @@ mod tests {
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx,
@@ -1310,6 +1354,7 @@ mod tests {
             tcp_read,
             tcp_write,
             write_rx,
+            Arc::new(Notify::new()),
             session.clone(),
             crypto.clone(),
         ));
@@ -1357,6 +1402,7 @@ mod tests {
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx,
@@ -1374,6 +1420,7 @@ mod tests {
             tcp_read,
             tcp_write,
             write_rx,
+            Arc::new(Notify::new()),
             session.clone(),
             crypto,
         ));
@@ -1420,6 +1467,7 @@ mod tests {
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx,
@@ -1435,6 +1483,7 @@ mod tests {
             tcp_read,
             tcp_write,
             write_rx,
+            Arc::new(Notify::new()),
             session.clone(),
             crypto.clone(),
         ));
@@ -1496,6 +1545,7 @@ mod tests {
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx,
@@ -1511,6 +1561,7 @@ mod tests {
             tcp_read,
             tcp_write,
             write_rx,
+            Arc::new(Notify::new()),
             session.clone(),
             crypto,
         ));
@@ -1552,6 +1603,7 @@ mod tests {
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx: old_tx,
@@ -1566,6 +1618,7 @@ mod tests {
             tcp_read,
             tcp_write,
             write_rx,
+            Arc::new(Notify::new()),
             session.clone(),
             crypto.clone(),
         ));
@@ -1600,6 +1653,7 @@ mod tests {
         let (sse_tx, _sse_rx) = mpsc::channel::<Vec<u8>>(16);
         let session = Arc::new(Mutex::new(Session {
             tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
             #[cfg(unix)]
             pty_resize: HashMap::new(),
             sse_tx,
@@ -1628,4 +1682,83 @@ mod tests {
             .expect("watchdog stranded the session lock: every send_to_client would park here");
         drop(regained);
     }
+
+    /// `Message::Abort` must release the target entirely, not just the upload
+    /// direction. `Close` deliberately keeps the read task pulling the target's
+    /// output - the half-close an app that finished sending relies on - so a
+    /// client whose app *aborted* used to leave this relay streaming the whole
+    /// remaining response into a conn_id the client had already forgotten.
+    /// Real time: nothing here waits on a timer, and the SSE receiver is
+    /// drained so every delivery succeeds on its first attempt.
+    #[tokio::test]
+    async fn an_abort_releases_a_target_that_is_still_sending() {
+        const CONN_ID: u32 = 47;
+
+        // Target that streams until its socket fails, and reports when it did.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let Ok((mut sock, _)) = target.accept().await else { return };
+            let chunk = vec![7u8; 65536];
+            while sock.write_all(&chunk).await.is_ok() {}
+            let _ = closed_tx.send(());
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // A healthy, draining client, so the response is flowing when the
+        // abort lands and nothing else could end the read task.
+        let (sse_tx, mut sse_rx) = mpsc::channel::<Vec<u8>>(16);
+        tokio::spawn(async move { while sse_rx.recv().await.is_some() {} });
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let abort = Arc::new(Notify::new());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+        {
+            let mut sess = session.lock().await;
+            sess.tcp_writers.insert(CONN_ID, write_tx);
+            sess.aborts.insert(CONN_ID, abort.clone());
+        }
+
+        let relay = tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            abort,
+            session.clone(),
+            crypto,
+        ));
+
+        // Let the response get going, then abort exactly as handle_send does.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(!relay.is_finished(), "relay ended before the abort");
+        {
+            let mut sess = session.lock().await;
+            sess.tcp_writers.remove(&CONN_ID);
+            sess.aborts.remove(&CONN_ID).expect("abort signal was registered").notify_one();
+        }
+
+        tokio::time::timeout(Duration::from_secs(10), relay)
+            .await
+            .expect("relay kept pulling the target after the client aborted")
+            .expect("relay task panicked");
+        tokio::time::timeout(Duration::from_secs(10), closed_rx)
+            .await
+            .expect("target socket was not released by the abort")
+            .unwrap();
+        assert!(session.lock().await.aborts.is_empty(), "abort signal should be cleaned up");
+    }
+
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1031,12 +1031,23 @@ const SSE_DEAD_GRACE: Duration = Duration::from_secs(6);
 /// Relays that can be left waiting on the client select on this to bound their
 /// teardown. A reconnect replaces `sse_tx` with a live sender and resets the
 /// count, so transient drops don't tear down a healthy session.
+///
+/// `try_lock`, never `lock().await`: callers hold this future inside a
+/// `select!` that stops polling it the instant the other branch wins, and
+/// tokio's mutex is fair - it hands the freed lock to the waiter at the head of
+/// its queue whether or not anyone is still polling it. A watchdog that queued
+/// there would strand the lock, and every later `send_to_client` on that
+/// session would park on it forever. A tick that loses the race is simply
+/// skipped: the counter is left alone rather than reset, so a contended lock
+/// delays this watchdog but cannot defeat it.
 async fn await_sse_dead(session: Arc<Mutex<Session>>) {
     let mut closed_secs: u32 = 0;
     let grace_secs = SSE_DEAD_GRACE.as_secs() as u32;
     loop {
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let closed = session.lock().await.sse_tx.is_closed();
+        let Ok(sess) = session.try_lock() else { continue };
+        let closed = sess.sse_tx.is_closed();
+        drop(sess);
         if closed {
             closed_secs += 1;
             if closed_secs >= grace_secs {
@@ -1462,5 +1473,46 @@ mod tests {
             Message::Close { conn_id } => assert_eq!(conn_id, CONN_ID),
             other => panic!("expected Close, got {:?}", other),
         }
+    }
+
+    /// The watchdog lives inside a `select!` that stops polling it the moment
+    /// the other branch wins. Tokio's mutex is fair, so a freed lock is handed
+    /// to the waiter at the head of its queue whether or not anyone is still
+    /// polling it: a watchdog that queued on `session.lock()` strands the lock,
+    /// and every later `send_to_client` on that session parks on it forever -
+    /// the relay goes silent mid-connection with no error anywhere.
+    /// Time is paused, so the watchdog's tick elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn the_sse_watchdog_never_strands_the_session_lock() {
+        let (sse_tx, _sse_rx) = mpsc::channel::<Vec<u8>>(16);
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+
+        // Someone else holds the lock, as `handle_send` briefly does for every
+        // uploaded chunk.
+        let held = session.clone().lock_owned().await;
+
+        let watchdog = await_sse_dead(session.clone());
+        tokio::pin!(watchdog);
+        // Poll the watchdog past its first tick, into the point where it wants
+        // the session lock, then abandon it - exactly what `select!` does each
+        // time the relay's other branch wins.
+        for _ in 0..5 {
+            tokio::select! {
+                biased;
+                _ = &mut watchdog => unreachable!("the stream is live; this must not fire"),
+                _ = tokio::time::sleep(Duration::from_millis(400)) => {}
+            }
+        }
+
+        drop(held);
+        let regained = tokio::time::timeout(Duration::from_secs(30), session.lock())
+            .await
+            .expect("watchdog stranded the session lock: every send_to_client would park here");
+        drop(regained);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1014,30 +1014,8 @@ async fn forward_pty_chunk(
     session: &Arc<Mutex<Session>>,
 ) -> bool {
     let msg = Message::Data { conn_id, data };
-    let bytes = match msg.to_bytes() {
-        Ok(b) => b,
-        Err(e) => { error!("[{}] PTY serialize: {}", conn_id, e); return false; }
-    };
-    let encrypted = match crypto.encrypt(&bytes) {
-        Ok(e) => e,
-        Err(e) => { error!("[{}] PTY encrypt: {}", conn_id, e); return false; }
-    };
-    for _ in 0..50 {
-        let sse_tx = {
-            let sess = session.lock().await;
-            sess.sse_tx.clone()
-        };
-        // Bound each send: a half-open client keeps the old bounded channel's
-        // receiver alive-but-undrained, so send() would park forever and defeat
-        // the re-fetch above. On timeout, fall through to pick up a reconnect.
-        if tokio::time::timeout(Duration::from_millis(500), sse_tx.send(encrypted.clone()))
-            .await
-            .is_ok_and(|r| r.is_ok())
-        {
-            return true;
-        }
-        debug!("[{}] SSE stream replaced or closed; retrying", conn_id);
-        tokio::time::sleep(Duration::from_millis(100)).await;
+    if send_to_client(conn_id, &msg, crypto, session).await {
+        return true;
     }
     error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
     false
@@ -1178,24 +1156,9 @@ async fn relay_push(
     // Watchdog: a client that dies mid-push (network drop, killed process)
     // never sends Close, so its writer sender lingers in `tcp_writers` and the
     // decompressor parks forever on a truncated archive's blocking read. Mirror
-    // the PTY watchdog — once SSE has been closed continuously for 6s, drop the
+    // the PTY watchdog — once SSE has been closed for SSE_DEAD_GRACE, drop the
     // writer to force EOF so the unpack fails cleanly instead of hanging.
-    let session_watch = session.clone();
-    let watchdog = async move {
-        let mut closed_secs: u32 = 0;
-        loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            let closed = session_watch.lock().await.sse_tx.is_closed();
-            if closed {
-                closed_secs += 1;
-                if closed_secs >= 6 {
-                    return;
-                }
-            } else {
-                closed_secs = 0;
-            }
-        }
-    };
+    let watchdog = await_sse_dead(session.clone());
 
     tokio::pin!(unpack_handle);
     let join = tokio::select! {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1319,6 +1319,18 @@ async fn relay_push(
 mod tests {
     use super::*;
 
+    /// Build a `Session` for a test. Centralised so that adding a field is one
+    /// edit here rather than one in every test - as adding `aborts` was.
+    fn test_session(sse_tx: mpsc::Sender<Vec<u8>>) -> Arc<Mutex<Session>> {
+        Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }))
+    }
+
     /// A terminal `Close` must survive an SSE queue that is momentarily full.
     /// The relay used to make a single 500ms attempt and give up, so a client
     /// that stalled (or was mid-reconnect) never learned the target closed and
@@ -1345,13 +1357,7 @@ mod tests {
         sse_tx.send(b"already queued".to_vec()).await.unwrap();
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
 
         // Keep the writer alive so only the read half drives teardown.
         let (_write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
@@ -1409,13 +1415,7 @@ mod tests {
         drop(sse_rx);
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
 
         // Registered writer, held open the way a live client's would be: only
         // the client's Close would normally remove it, and it never arrives.
@@ -1474,13 +1474,7 @@ mod tests {
         let (sse_tx, mut sse_rx) = mpsc::channel::<Vec<u8>>(16);
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
 
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
         session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
@@ -1552,13 +1546,7 @@ mod tests {
         drop(sse_rx);
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
 
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
         session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
@@ -1610,13 +1598,7 @@ mod tests {
         old_tx.send(b"stale".to_vec()).await.unwrap();
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx: old_tx,
-        }));
+        let session = test_session(old_tx);
 
         let (_write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
 
@@ -1660,13 +1642,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn the_sse_watchdog_never_strands_the_session_lock() {
         let (sse_tx, _sse_rx) = mpsc::channel::<Vec<u8>>(16);
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
 
         // Someone else holds the lock, as `handle_send` briefly does for every
         // uploaded chunk.
@@ -1724,13 +1700,7 @@ mod tests {
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
         let abort = Arc::new(Notify::new());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
         {
             let mut sess = session.lock().await;
@@ -1799,13 +1769,7 @@ mod tests {
         drop(sse_rx);
 
         let crypto = Arc::new(Crypto::new("test-password").unwrap());
-        let session = Arc::new(Mutex::new(Session {
-            tcp_writers: HashMap::new(),
-            aborts: HashMap::new(),
-            #[cfg(unix)]
-            pty_resize: HashMap::new(),
-            sse_tx,
-        }));
+        let session = test_session(sse_tx);
         let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
         session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -630,14 +630,21 @@ async fn relay_tcp_connection(
             }
         }
 
-        // The client's relay ends its response direction on this Close, so it
-        // has to arrive: retry across a reconnect instead of making a single
-        // attempt that a momentarily-full queue would defeat.
-        if !client_gone {
+        if client_gone {
+            // No further uploads can arrive, so drop the writer to keep
+            // teardown bounded: the write task ends once its sender is gone.
+            session_clone.lock().await.tcp_writers.remove(&conn_id);
+        } else {
+            // The client's relay ends its response direction on this Close, so
+            // it has to arrive: retry across a reconnect instead of making a
+            // single attempt that a momentarily-full queue would defeat.
             let _ = send_to_client(conn_id, &Message::Close { conn_id }, &crypto_clone, &session_clone).await;
+            // Deliberately keeping the writer registered: the target closing
+            // its output says nothing about the client's upload, which may
+            // still be in flight. handle_send drops the writer when the
+            // client's own Close arrives, and that is what shuts the target's
+            // write side down.
         }
-        let mut sess = session_clone.lock().await;
-        sess.tcp_writers.remove(&conn_id);
     });
 
     let write_task = tokio::spawn(async move {
@@ -653,10 +660,16 @@ async fn relay_tcp_connection(
         }
     });
 
-    tokio::select! {
-        _ = read_task => {},
-        _ = write_task => {},
-    }
+    // Both directions run to completion independently: the target closing its
+    // output must not cut off an upload still in progress, and a finished
+    // upload must not cut off target output still arriving. The write task ends
+    // when the client's Close drops its sender, or on a target write error.
+    let (_, _) = tokio::join!(read_task, write_task);
+
+    // Idempotent: the normal paths already removed the writer (client Close, or
+    // the client-gone branch above). This catches a target write error, which
+    // ends the write task with the entry still registered.
+    session.lock().await.tcp_writers.remove(&conn_id);
 
     info!("[{}] Connection closed for {}:{}", conn_id, host, port);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -601,8 +601,24 @@ async fn relay_tcp_connection(
         let mut client_gone = false;
         // Set when the target itself failed, as opposed to closing cleanly.
         let mut read_failure: Option<String> = None;
+        // A silent target gives this task nothing to react to, so a vanished
+        // client would otherwise leave it blocked on read() forever, holding
+        // the target socket. The delivery retries below only notice a dead
+        // client when a chunk actually arrives. Pinned once: the counter resets
+        // itself whenever the stream is live.
+        let sse_dead = await_sse_dead(session_clone.clone());
+        tokio::pin!(sse_dead);
         loop {
-            match tcp_read.read(&mut buf).await {
+            let read = tokio::select! {
+                // Cancel-safe: no bytes are consumed if the other branch wins.
+                result = tcp_read.read(&mut buf) => result,
+                _ = &mut sse_dead => {
+                    debug!("[{}] SSE closed continuously; abandoning target read", conn_id);
+                    client_gone = true;
+                    break;
+                }
+            };
+            match read {
                 Ok(0) => {
                     debug!("[{}] TCP EOF", conn_id);
                     break;
@@ -671,13 +687,13 @@ async fn relay_tcp_connection(
 
     let session_watch = session.clone();
     let write_task = tokio::spawn(async move {
+        // The writer now outlives target-output EOF, so nothing else would wake
+        // this task if the client vanished without sending Close. Bound the
+        // wait on the client the same way the PTY relay does. Pinned once, like
+        // the PTY relay: the counter resets itself whenever the stream is live.
+        let sse_dead = await_sse_dead(session_watch.clone());
+        tokio::pin!(sse_dead);
         loop {
-            // The writer now outlives target-output EOF, so nothing else would
-            // wake this task if the client vanished without sending Close.
-            // Bound the wait on the client the same way the PTY relay does.
-            let sse_dead = await_sse_dead(session_watch.clone());
-            tokio::pin!(sse_dead);
-
             let data = tokio::select! {
                 received = write_rx.recv() => match received {
                     Some(data) => data,
@@ -694,6 +710,17 @@ async fn relay_tcp_connection(
             debug!("[{}] Client -> TCP {} bytes", conn_id, data.len());
             if let Err(e) = tcp_write.write_all(&data).await {
                 error!("[{}] TCP write error: {}", conn_id, e);
+                // The upload direction is broken. Release the writer now rather
+                // than at teardown: until it goes, handle_send keeps accepting
+                // client bytes into a channel nobody drains and answering 200,
+                // so the client uploads into nothing. Then tell it, so a failed
+                // upload is visible instead of silently discarded.
+                session_watch.lock().await.tcp_writers.remove(&conn_id);
+                let msg = Message::Error {
+                    conn_id: Some(conn_id),
+                    message: format!("target write failed: {}", e),
+                };
+                let _ = send_to_client(conn_id, &msg, &crypto, &session_watch).await;
                 break;
             }
         }
@@ -1053,6 +1080,12 @@ async fn await_sse_dead(session: Arc<Mutex<Session>>) {
 /// relays, PTY teardown and transfers. Terminal messages (`Close`, `Error`,
 /// `ExitStatus`) must go through here: a single send loses them whenever the
 /// client's queue is momentarily full or its SSE stream is being replaced.
+///
+/// The budget here (50 x (500ms + 100ms) ~= 30s) is what declares a client
+/// unreachable, so it must stay well above the client's `DISPATCH_STALL_TIMEOUT`
+/// in tunnel.rs. That timeout is how long one stalled consumer can keep the
+/// client from reading the SSE socket; if the two were the same magnitude, that
+/// stall alone would exhaust this budget and tear down healthy connections.
 async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &Arc<Mutex<Session>>) -> bool {
     let bytes = match msg.to_bytes() {
         Ok(b) => b,
@@ -1333,6 +1366,63 @@ mod tests {
             !session.lock().await.tcp_writers.contains_key(&CONN_ID),
             "writer should have been cleaned up after teardown"
         );
+    }
+
+    /// The same teardown bound, but with an idle target: it never sends and
+    /// never closes, so the read side has nothing to react to and the delivery
+    /// retries never run. Without a watchdog there the task blocks on read()
+    /// forever, leaking the task, the socket and the session entry.
+    #[tokio::test(start_paused = true)]
+    async fn read_side_gives_up_when_the_client_vanishes() {
+        const CONN_ID: u32 = 45;
+
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        // Accept and hold: silent, but very much open.
+        let held = tokio::spawn(async move {
+            let accepted = target.accept().await;
+            std::future::pending::<()>().await;
+            drop(accepted);
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        let (sse_tx, sse_rx) = mpsc::channel::<Vec<u8>>(16);
+        drop(sse_rx);
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+        session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
+
+        let relay = tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            session.clone(),
+            crypto,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(600), relay)
+            .await
+            .expect("relay never finished: the read side blocked on an idle target")
+            .expect("relay task panicked");
+
+        assert!(
+            !session.lock().await.tcp_writers.contains_key(&CONN_ID),
+            "writer should have been cleaned up after teardown"
+        );
+        held.abort();
     }
 
     /// A terminal `Close` must follow the client across an SSE reconnect. The

--- a/src/server.rs
+++ b/src/server.rs
@@ -729,13 +729,16 @@ async fn relay_tcp_connection(
             // The client's relay ends its response direction on this message,
             // so it has to arrive: retry across a reconnect instead of making a
             // single attempt that a momentarily-full queue would defeat.
-            if send_to_client(conn_id, &terminal, &crypto_clone, &session_clone).await {
-                // Deliberately keeping the writer registered: the target
-                // closing its output says nothing about the client's upload,
-                // which may still be in flight. handle_send drops the writer
-                // when the client's own Close arrives, and that is what shuts
-                // the target's write side down.
-            } else {
+            //
+            // On success the writer is deliberately kept registered: the
+            // target closing its output says nothing about the client's
+            // upload, which may still be in flight. handle_send drops the
+            // writer when the client's own Close (or Abort) arrives, and that
+            // is what shuts the target's write side down. Until then this
+            // relay holds the target socket, and there is no idle timeout on
+            // either side: an app that never closes its half-open connection
+            // holds a target socket here for as long as the client runs.
+            if !send_to_client(conn_id, &terminal, &crypto_clone, &session_clone).await {
                 // The client exhausted the delivery budget, so its Close is
                 // not coming either. Release the writer now instead of leaving
                 // the write task to wait on the SSE watchdog, which never
@@ -920,7 +923,9 @@ async fn relay_pty_connection(
                 }) {
                     Ok(Ok(0)) => break, // EOF: slave fully closed
                     Ok(Ok(n)) => {
-                        if !forward_pty_chunk(conn_id, buf[..n].to_vec(), &crypto_fwd, &session_fwd).await {
+                        let msg = Message::Data { conn_id, data: buf[..n].to_vec() };
+                        if !send_to_client(conn_id, &msg, &crypto_fwd, &session_fwd).await {
+                            error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
                             break;
                         }
                     }
@@ -984,8 +989,8 @@ async fn relay_pty_connection(
     // Watchdog: an abrupt client disconnect (network drop, process killed)
     // leaves write_tx in tcp_writers, so write_blocking never finishes and the
     // child runs forever. Probe the session's sse_tx; only kill the child if
-    // SSE has been continuously closed for at least 6s, so transient drops
-    // (e.g., a client reconnect within forward_pty_chunk's 5s retry window)
+    // SSE has been continuously closed for SSE_DEAD_GRACE, so transient drops
+    // (e.g., a client reconnect within send_to_client's retry window)
     // don't kill an otherwise-healthy session.
     let sse_dead = await_sse_dead(session.clone());
     // Pin to the stack so we can re-poll across loop iterations; the async
@@ -1043,7 +1048,7 @@ async fn relay_pty_connection(
         Message::Close { conn_id },
     ] {
         // When the client is already known gone (writer closed, or SSE dead
-        // ≥6s past the reconnect window) one best-effort attempt is enough:
+        // for SSE_DEAD_GRACE) one best-effort attempt is enough:
         // spending the full budget only delays teardown to rediscover that.
         let attempts = if client_gone { 1 } else { SEND_ATTEMPTS };
         let sent = send_to_client_with_attempts(conn_id, &msg, &crypto, &session, attempts).await;
@@ -1069,28 +1074,21 @@ async fn relay_pty_connection(
     info!("[{}] PTY session closed (exit {})", conn_id, code);
 }
 
-/// Encrypt one PTY chunk and push it to the (possibly-reconnected) SSE sender.
-/// Retries briefly across a client reconnect so a transient SSE drop doesn't
-/// lose output. Returns false if the chunk could not be delivered.
-#[cfg(unix)]
-async fn forward_pty_chunk(
-    conn_id: u32,
-    data: Vec<u8>,
-    crypto: &Crypto,
-    session: &Arc<Mutex<Session>>,
-) -> bool {
-    let msg = Message::Data { conn_id, data };
-    if send_to_client(conn_id, &msg, crypto, session).await {
-        return true;
-    }
-    error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
-    false
-}
-
 /// How long a session's SSE stream must stay continuously closed before its
-/// relays treat the client as gone. Long enough that a client reconnecting
-/// inside the send retry window doesn't count as a disconnect.
-const SSE_DEAD_GRACE: Duration = Duration::from_secs(6);
+/// relays treat the client as gone.
+///
+/// A trade between two costs. Too short, and a client that is merely slow to
+/// reconnect loses its idle connections: its reconnect is a fixed 3s sleep
+/// plus a GET that can take several seconds through a reverse proxy, and 6s
+/// cleared the sleep with little to spare. Too long, and a client that really
+/// is gone keeps its PTY children running and its target sockets held for the
+/// whole wait. 10s leaves the GET 7s and still reaps within seconds.
+///
+/// Deliberately shorter than the 30s `send_to_client` budget, so an idle
+/// connection gives up on a vanished client sooner than an active one: the
+/// active one is at least still moving bytes for that budget, while the idle
+/// one is only holding resources.
+const SSE_DEAD_GRACE: Duration = Duration::from_secs(10);
 
 /// Resolves once this session's SSE stream has been closed continuously for
 /// `SSE_DEAD_GRACE`.
@@ -1131,16 +1129,17 @@ async fn await_sse_dead(session: Arc<Mutex<Session>>) {
 
 /// Encrypt `msg` and push it to the (possibly-reconnected) SSE sender, retrying
 /// briefly across a client reconnect. Returns false if it could not be
-/// delivered. Cross-platform sibling of `forward_pty_chunk`; used by TCP
-/// relays, PTY teardown and transfers. Terminal messages (`Close`, `Error`,
+/// delivered. Used by TCP relays, PTY output and teardown, and transfers. Terminal messages (`Close`, `Error`,
 /// `ExitStatus`) must go through here: a single send loses them whenever the
 /// client's queue is momentarily full or its SSE stream is being replaced.
 ///
-/// The budget here (50 x (500ms + 100ms) ~= 30s) is what declares a client
-/// unreachable, so it must stay well above the client's `DISPATCH_STALL_TIMEOUT`
-/// in tunnel.rs. That timeout is how long one stalled consumer can keep the
-/// client from reading the SSE socket; if the two were the same magnitude, that
-/// stall alone would exhaust this budget and tear down healthy connections.
+/// The budget here (`SEND_ATTEMPTS` x `SEND_ATTEMPT_INTERVAL` = 30s of wall
+/// clock) is what declares a client unreachable, so two other constants are
+/// sized against it. It must stay well above the client's
+/// `DISPATCH_STALL_TIMEOUT` in tunnel.rs: that is how long one stalled consumer
+/// can keep the client from reading the SSE socket, and at the same magnitude
+/// that stall alone would exhaust this budget and tear down healthy
+/// connections. `SSE_DEAD_GRACE` is deliberately shorter - see its note.
 async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &Arc<Mutex<Session>>) -> bool {
     send_to_client_with_attempts(conn_id, msg, crypto, session, SEND_ATTEMPTS).await
 }
@@ -1149,6 +1148,13 @@ async fn send_to_client(conn_id: u32, msg: &Message, crypto: &Crypto, session: &
 /// unreachable. See the note on that function for why the resulting budget has
 /// to stay well above the client's `DISPATCH_STALL_TIMEOUT`.
 const SEND_ATTEMPTS: u32 = 50;
+/// Wall-clock spacing of those attempts. Each attempt is paced to this rather
+/// than to a fixed backoff: a *full* channel (client stalled) costs the 500ms
+/// send timeout, but a *closed* one (client mid-reconnect) fails instantly, and
+/// pacing by attempt count alone gave a reconnecting client 50 x 100ms = 5s
+/// against a stalled client's 30s. The client's reconnect is a 3s sleep plus a
+/// GET, so 5s was tearing down healthy connections across ordinary reconnects.
+const SEND_ATTEMPT_INTERVAL: Duration = Duration::from_millis(600);
 
 /// `send_to_client` with an explicit attempt budget. Only teardown paths that
 /// already know the client is gone should pass anything but `SEND_ATTEMPTS`:
@@ -1170,6 +1176,7 @@ async fn send_to_client_with_attempts(
         Err(e) => { error!("[{}] encrypt: {}", conn_id, e); return false; }
     };
     for attempt in 0..attempts {
+        let started = tokio::time::Instant::now();
         let sse_tx = {
             let sess = session.lock().await;
             sess.sse_tx.clone()
@@ -1185,9 +1192,11 @@ async fn send_to_client_with_attempts(
         }
         // Space out retries only when there is another one coming: a caller
         // that already knows the client is gone spends one attempt, and should
-        // not pay a backoff on its way to giving up.
+        // not pay a backoff on its way to giving up. Paced to the interval by
+        // wall clock, so a closed channel's instant failure and a full
+        // channel's 500ms timeout both spend the same budget.
         if attempt + 1 < attempts {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(SEND_ATTEMPT_INTERVAL.saturating_sub(started.elapsed())).await;
         }
     }
     false
@@ -1761,4 +1770,85 @@ mod tests {
         assert!(session.lock().await.aborts.is_empty(), "abort signal should be cleaned up");
     }
 
+    /// The mirror of the give-up tests: a client that reconnects *inside* the
+    /// grace must not lose its connections, even if its stream drops again
+    /// later. Every other watchdog test proves the bound fires; this one pins
+    /// that it counts *continuously* closed time - two closed stretches with a
+    /// reconnect between them must not add up, however long they total - and
+    /// then that it still fires once the stream really does stay down. Time is
+    /// paused, so the grace elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn a_reconnect_inside_the_grace_does_not_tear_down() {
+        const CONN_ID: u32 = 48;
+
+        // Silent target, held open: nothing but the watchdog could end the
+        // read side, and nothing but the watchdog could end the write side.
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        let held = tokio::spawn(async move {
+            let accepted = target.accept().await;
+            std::future::pending::<()>().await;
+            drop(accepted);
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // The client's stream drops at t=0.
+        let (sse_tx, sse_rx) = mpsc::channel::<Vec<u8>>(16);
+        drop(sse_rx);
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            aborts: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+        session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
+
+        let relay = tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            Arc::new(Notify::new()),
+            session.clone(),
+            crypto,
+        ));
+
+        // Most of the grace passes with the stream closed...
+        tokio::time::sleep(SSE_DEAD_GRACE - Duration::from_secs(2)).await;
+        assert!(!relay.is_finished(), "relay gave up before the grace elapsed");
+
+        // ...then the client reconnects: handle_stream swaps in a live sender,
+        // and the watchdog gets a few ticks to see it.
+        let (live_tx, live_rx) = mpsc::channel::<Vec<u8>>(16);
+        session.lock().await.sse_tx = live_tx;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // The stream drops again for most of another grace. Total closed time
+        // is now well past the grace; continuous closed time is not.
+        drop(live_rx);
+        tokio::time::sleep(SSE_DEAD_GRACE - Duration::from_secs(2)).await;
+        assert!(
+            !relay.is_finished(),
+            "two closed stretches with a reconnect between them were added up"
+        );
+        assert!(
+            session.lock().await.tcp_writers.contains_key(&CONN_ID),
+            "writer should still be registered for a client that reconnected"
+        );
+
+        // Left down for good, it does fire: the watchdog was live all along.
+        tokio::time::timeout(Duration::from_secs(600), relay)
+            .await
+            .expect("stream stayed closed past the grace but the relay never gave up")
+            .expect("relay task panicked");
+        held.abort();
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -647,8 +647,25 @@ async fn relay_tcp_connection(
         }
     });
 
+    let session_watch = session.clone();
     let write_task = tokio::spawn(async move {
-        while let Some(data) = write_rx.recv().await {
+        loop {
+            // The writer now outlives target-output EOF, so nothing else would
+            // wake this task if the client vanished without sending Close.
+            // Bound the wait on the client the same way the PTY relay does.
+            let sse_dead = await_sse_dead(session_watch.clone());
+            tokio::pin!(sse_dead);
+
+            let data = tokio::select! {
+                received = write_rx.recv() => match received {
+                    Some(data) => data,
+                    None => break,
+                },
+                _ = &mut sse_dead => {
+                    debug!("[{}] SSE closed continuously; ending TCP write side", conn_id);
+                    break;
+                }
+            };
             if data.is_empty() {
                 continue;
             }
@@ -840,22 +857,7 @@ async fn relay_pty_connection(
     // SSE has been continuously closed for at least 6s, so transient drops
     // (e.g., a client reconnect within forward_pty_chunk's 5s retry window)
     // don't kill an otherwise-healthy session.
-    let session_watch = session.clone();
-    let sse_dead = async move {
-        let mut closed_secs: u32 = 0;
-        loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            let sess = session_watch.lock().await;
-            if sess.sse_tx.is_closed() {
-                closed_secs += 1;
-                if closed_secs >= 6 {
-                    return;
-                }
-            } else {
-                closed_secs = 0;
-            }
-        }
-    };
+    let sse_dead = await_sse_dead(session.clone());
     // Pin to the stack so we can re-poll across loop iterations; the async
     // block holds a !Unpin MutexGuard across .await.
     tokio::pin!(sse_dead);
@@ -990,6 +992,37 @@ async fn forward_pty_chunk(
     }
     error!("[{}] SSE reconnect timed out; dropping PTY output", conn_id);
     false
+}
+
+/// How long a session's SSE stream must stay continuously closed before its
+/// relays treat the client as gone. Long enough that a client reconnecting
+/// inside the send retry window doesn't count as a disconnect.
+const SSE_DEAD_GRACE: Duration = Duration::from_secs(6);
+
+/// Resolves once this session's SSE stream has been closed continuously for
+/// `SSE_DEAD_GRACE`.
+///
+/// An abrupt client disconnect (network drop, killed process) leaves a writer
+/// registered in `tcp_writers` with nothing left to drain it, so a relay's
+/// write task would park on `recv()` forever, holding its target socket open.
+/// Relays that can be left waiting on the client select on this to bound their
+/// teardown. A reconnect replaces `sse_tx` with a live sender and resets the
+/// count, so transient drops don't tear down a healthy session.
+async fn await_sse_dead(session: Arc<Mutex<Session>>) {
+    let mut closed_secs: u32 = 0;
+    let grace_secs = SSE_DEAD_GRACE.as_secs() as u32;
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let closed = session.lock().await.sse_tx.is_closed();
+        if closed {
+            closed_secs += 1;
+            if closed_secs >= grace_secs {
+                return;
+            }
+        } else {
+            closed_secs = 0;
+        }
+    }
 }
 
 /// Encrypt `msg` and push it to the (possibly-reconnected) SSE sender, retrying
@@ -1219,6 +1252,65 @@ mod tests {
             Message::Close { conn_id } => assert_eq!(conn_id, CONN_ID),
             other => panic!("expected Close, got {:?}", other),
         }
+    }
+
+    /// A client that vanishes after the target closed its output must not leave
+    /// the relay parked. The writer deliberately outlives target-output EOF so
+    /// uploads can finish, which means nothing else will ever wake the write
+    /// task — only the SSE watchdog can end it. Time is paused, so the grace
+    /// period elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn write_side_gives_up_when_the_client_vanishes() {
+        const CONN_ID: u32 = 44;
+
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((sock, _)) = target.accept().await {
+                drop(sock);
+            }
+        });
+
+        let stream = TcpStream::connect(target_addr).await.unwrap();
+        let (tcp_read, tcp_write) = stream.into_split();
+
+        // Client is gone: its SSE receiver is dropped, so sse_tx is closed.
+        let (sse_tx, sse_rx) = mpsc::channel::<Vec<u8>>(16);
+        drop(sse_rx);
+
+        let crypto = Arc::new(Crypto::new("test-password").unwrap());
+        let session = Arc::new(Mutex::new(Session {
+            tcp_writers: HashMap::new(),
+            #[cfg(unix)]
+            pty_resize: HashMap::new(),
+            sse_tx,
+        }));
+
+        // Registered writer, held open the way a live client's would be: only
+        // the client's Close would normally remove it, and it never arrives.
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(4);
+        session.lock().await.tcp_writers.insert(CONN_ID, write_tx);
+
+        let relay = tokio::spawn(relay_tcp_connection(
+            CONN_ID,
+            "127.0.0.1",
+            target_addr.port(),
+            tcp_read,
+            tcp_write,
+            write_rx,
+            session.clone(),
+            crypto,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(600), relay)
+            .await
+            .expect("relay never finished: the write side parked on a dead client")
+            .expect("relay task panicked");
+
+        assert!(
+            !session.lock().await.tcp_writers.contains_key(&CONN_ID),
+            "writer should have been cleaned up after teardown"
+        );
     }
 
     /// A terminal `Close` must follow the client across an SSE reconnect. The

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -28,14 +28,20 @@ const CONN_CHANNEL_CAPACITY: usize = 256;
 /// dispatch loop, so an unbounded wait here starves every other connection on
 /// the tunnel.
 ///
-/// Must stay well under the server's per-message delivery budget in
-/// `send_to_client` (50 attempts x (500ms + 100ms) ~= 30s). Dispatch runs
-/// inline in the SSE read loop, so this is also how long the client can go
-/// without reading the SSE socket at all: at the same magnitude as that budget,
-/// one stalled consumer would let the server exhaust its retries on unrelated
-/// healthy connections and tear them down as unreachable. 5s is still ~20x what
-/// a draining 256-slot queue needs.
-const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(5);
+/// This is a stopgap, not backpressure: a proxied app that simply stops
+/// reading for this long with a full queue (~8MB buffered) has its connection
+/// reset, where TCP would have made the target wait. Real per-connection
+/// backpressure needs flow control in the protocol; until then the value is a
+/// trade between tolerating a paused consumer and the constraint below.
+///
+/// It must stay well under the server's per-message delivery budget in
+/// `send_to_client` (30s of wall clock). Dispatch runs inline in the SSE read
+/// loop, so this is also how long the client can go without reading the SSE
+/// socket at all: at the same magnitude as that budget, one stalled consumer
+/// would let the server exhaust its retries on unrelated healthy connections
+/// and tear them down as unreachable. 15s leaves that budget a 2x margin, and
+/// is still far more than a draining 256-slot queue needs.
+const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(15);
 /// How long a stalled `Close` may wait off the dispatch loop before its
 /// connection is given up on. Generous where `DISPATCH_STALL_TIMEOUT` is tight:
 /// this wait blocks no other connection, and the alternative is resetting an
@@ -653,5 +659,47 @@ pub(crate) mod tests {
             matches!(rx.recv().await, Some(TunnelEvent::Close)),
             "the handed-off Close never arrived"
         );
+    }
+
+    /// The mirror of the stall test: a consumer that is slow but *does* make
+    /// progress inside the timeout must keep its connection. The stall test
+    /// only proves the bound fires; this one pins that it does not fire early,
+    /// which is what makes the timeout a bound on wedged consumers rather than
+    /// a penalty on merely slow ones. Time is paused, so the wait is instant.
+    #[tokio::test(start_paused = true)]
+    async fn a_slow_consumer_inside_the_stall_timeout_is_not_dropped() {
+        let tunnel = Arc::new(test_tunnel("pw"));
+        let mut rx = tunnel.register_connection(1).await;
+
+        // Fill the queue: the app has fallen behind.
+        let frame = sse_frame(&tunnel, &Message::Data { conn_id: 1, data: vec![3u8; 8] });
+        for _ in 0..CONN_CHANNEL_CAPACITY {
+            tunnel.handle_sse_message(&frame).await;
+        }
+
+        // One more has nowhere to go yet. Dispatch waits on it...
+        let dispatch = {
+            let tunnel = tunnel.clone();
+            let frame = frame.clone();
+            tokio::spawn(async move { tunnel.handle_sse_message(&frame).await })
+        };
+
+        // ...and the app frees a slot just inside the timeout.
+        tokio::time::sleep(DISPATCH_STALL_TIMEOUT - Duration::from_secs(1)).await;
+        assert!(!dispatch.is_finished(), "dispatch gave up before the timeout");
+        assert!(matches!(rx.recv().await, Some(TunnelEvent::Data(_))));
+
+        tokio::time::timeout(Duration::from_secs(600), dispatch)
+            .await
+            .expect("dispatch did not complete once a slot freed")
+            .unwrap();
+        assert!(
+            tunnel.response_channels.lock().await.contains_key(&1),
+            "a consumer that made progress inside the timeout was dropped"
+        );
+        // Everything queued, including the late one, is still there.
+        for _ in 0..CONN_CHANNEL_CAPACITY {
+            assert!(matches!(rx.try_recv(), Ok(TunnelEvent::Data(_))));
+        }
     }
 }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -36,6 +36,11 @@ const CONN_CHANNEL_CAPACITY: usize = 256;
 /// healthy connections and tear them down as unreachable. 5s is still ~20x what
 /// a draining 256-slot queue needs.
 const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long a stalled `Close` may wait off the dispatch loop before its
+/// connection is given up on. Generous where `DISPATCH_STALL_TIMEOUT` is tight:
+/// this wait blocks no other connection, and the alternative is resetting an
+/// app whose response was in fact complete.
+const CLOSE_HANDOFF_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Events received from server via SSE
 #[derive(Debug)]
@@ -398,6 +403,9 @@ impl Tunnel {
     /// its relay, which closes the local socket so the app sees the failure.
     /// Note this bounds the stall, not the latency: dispatch can still be held
     /// up for one timeout by a consumer that stops reading.
+    ///
+    /// `Close` is the exception, and is handed off instead of dropped — see
+    /// below.
     async fn dispatch_event(&self, conn_id: u32, event: TunnelEvent) {
         // Clone the sender out of the guard before awaiting: holding the mutex
         // across send() would block session ops and every other dispatch too.
@@ -407,16 +415,48 @@ impl Tunnel {
         };
         let Some(tx) = tx else { return };
 
-        if tokio::time::timeout(DISPATCH_STALL_TIMEOUT, tx.send(event))
-            .await
-            .is_err()
-        {
-            warn!(
-                "[{}] consumer stalled for {:?}; dropping the connection to keep the tunnel moving",
-                conn_id, DISPATCH_STALL_TIMEOUT
-            );
-            self.unregister_connection(conn_id).await;
+        // reserve() rather than send(): a send that loses its race with the
+        // timeout drops the event with it, and the stalled `Close` below has to
+        // survive to be handed off.
+        let stalled = match tokio::time::timeout(DISPATCH_STALL_TIMEOUT, tx.reserve()).await {
+            Ok(Ok(permit)) => {
+                permit.send(event);
+                return;
+            }
+            // Receiver gone: the relay already tore down. Nothing to report.
+            Ok(Err(_)) => return,
+            Err(_) => event,
+        };
+
+        // Dropping the connection here is right for a stalled `Data`: the
+        // response is truncated whatever we do, so the app has to be failed.
+        // A stalled `Close` is not - everything before it is already queued, so
+        // the app's response is complete and dropping the connection would
+        // reset it over nothing but the end-of-stream marker. Wait that one out
+        // off the dispatch loop, where it starves nobody. Ordering is safe: the
+        // only event that can follow a `Close` is a late `Error`, and an
+        // `Error` that overtakes it just fails the connection - which is what
+        // that `Error` means anyway.
+        if matches!(stalled, TunnelEvent::Close) {
+            debug!("[{}] consumer stalled; delivering Close off the dispatch loop", conn_id);
+            let channels = self.response_channels.clone();
+            tokio::spawn(async move {
+                if tokio::time::timeout(CLOSE_HANDOFF_TIMEOUT, tx.send(stalled))
+                    .await
+                    .is_err()
+                {
+                    warn!("[{}] consumer never took its Close; dropping the connection", conn_id);
+                    channels.lock().await.remove(&conn_id);
+                }
+            });
+            return;
         }
+
+        warn!(
+            "[{}] consumer stalled for {:?}; dropping the connection to keep the tunnel moving",
+            conn_id, DISPATCH_STALL_TIMEOUT
+        );
+        self.unregister_connection(conn_id).await;
     }
 
     /// Register a connection and return event receiver
@@ -576,5 +616,42 @@ pub(crate) mod tests {
             Ok(TunnelEvent::Data(d)) => assert_eq!(d, b"fine"),
             other => panic!("expected Data on the healthy conn, got {:?}", other),
         }
+    }
+
+    /// A `Close` that arrives while the consumer is stalled must not tear the
+    /// connection down: every byte before it is already queued, so the app's
+    /// response is complete and dropping it would reset the app over nothing
+    /// but the end-of-stream marker. Time is paused, so the stall timeout
+    /// elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_close_is_handed_off_rather_than_dropped() {
+        let tunnel = test_tunnel("pw");
+        let mut rx = tunnel.register_connection(1).await;
+
+        // Fill the queue: the app has stopped reading mid-response.
+        let data = sse_frame(&tunnel, &Message::Data { conn_id: 1, data: vec![7u8; 8] });
+        for _ in 0..CONN_CHANNEL_CAPACITY {
+            tunnel.handle_sse_message(&data).await;
+        }
+
+        // The Close has nowhere to go. Dispatch must neither park on it nor
+        // drop the connection because of it.
+        let close = sse_frame(&tunnel, &Message::Close { conn_id: 1 });
+        tokio::time::timeout(Duration::from_secs(600), tunnel.handle_sse_message(&close))
+            .await
+            .expect("dispatch loop parked on a stalled Close");
+        assert!(
+            tunnel.response_channels.lock().await.contains_key(&1),
+            "a stalled Close should not tear the connection down"
+        );
+
+        // The app resumes reading: it gets its whole response, then the Close.
+        for _ in 0..CONN_CHANNEL_CAPACITY {
+            assert!(matches!(rx.recv().await, Some(TunnelEvent::Data(_))));
+        }
+        assert!(
+            matches!(rx.recv().await, Some(TunnelEvent::Close)),
+            "the handed-off Close never arrived"
+        );
     }
 }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -387,7 +387,6 @@ impl Tunnel {
         }
     }
 
-    /// Register a connection and return event receiver
     /// Hand one event to a registered connection. Unknown conn_ids are a silent
     /// no-op (the relay may already have torn down).
     ///
@@ -420,6 +419,7 @@ impl Tunnel {
         }
     }
 
+    /// Register a connection and return event receiver
     pub async fn register_connection(&self, conn_id: u32) -> mpsc::Receiver<TunnelEvent> {
         let (tx, rx) = mpsc::channel(CONN_CHANNEL_CAPACITY);
         let mut channels = self.response_channels.lock().await;

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -26,9 +26,16 @@ const CONN_CHANNEL_CAPACITY: usize = 256;
 /// How long a single event may wait for one connection's consumer before that
 /// connection is declared wedged and dropped. All connections share one
 /// dispatch loop, so an unbounded wait here starves every other connection on
-/// the tunnel. Generous: a consumer making any progress at all drains a
-/// 256-slot queue well inside this.
-const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(30);
+/// the tunnel.
+///
+/// Must stay well under the server's per-message delivery budget in
+/// `send_to_client` (50 attempts x (500ms + 100ms) ~= 30s). Dispatch runs
+/// inline in the SSE read loop, so this is also how long the client can go
+/// without reading the SSE socket at all: at the same magnitude as that budget,
+/// one stalled consumer would let the server exhaust its retries on unrelated
+/// healthy connections and tear them down as unreachable. 5s is still ~20x what
+/// a draining 256-slot queue needs.
+const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Events received from server via SSE
 #[derive(Debug)]
@@ -428,13 +435,13 @@ impl Tunnel {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     /// Build a Tunnel without a live server. handle_sse_message only touches
     /// `hot.crypto` (to decrypt) and `response_channels` (to dispatch), so the
     /// http_client / server_base_url are placeholders.
-    fn test_tunnel(password: &str) -> Tunnel {
+    pub(crate) fn test_tunnel(password: &str) -> Tunnel {
         let hot = HotClientConfig {
             crypto: Arc::new(Crypto::new(password).unwrap()),
             http_client: reqwest::Client::new(),

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -20,6 +20,15 @@ const SSE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// that long under network congestion, and this also covers first-frame
 /// processing before sse_ready fires.
 const RECONNECT_WAIT: Duration = Duration::from_secs(20);
+/// Per-connection event queue depth. Deep enough that a merely slow local app
+/// keeps draining without stalling dispatch.
+const CONN_CHANNEL_CAPACITY: usize = 256;
+/// How long a single event may wait for one connection's consumer before that
+/// connection is declared wedged and dropped. All connections share one
+/// dispatch loop, so an unbounded wait here starves every other connection on
+/// the tunnel. Generous: a consumer making any progress at all drains a
+/// 256-slot queue well inside this.
+const DISPATCH_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Events received from server via SSE
 #[derive(Debug)]
@@ -263,48 +272,21 @@ impl Tunnel {
         match message {
             Message::Data { conn_id, data } => {
                 debug!("[{}] SSE data {} bytes", conn_id, data.len());
-                // Clone the sender out of the guard before awaiting send().
-                // Holding the mutex across `tx.send().await` lets one slow
-                // consumer (full channel) stall dispatch for every connection.
-                let tx = {
-                    let channels = self.response_channels.lock().await;
-                    channels.get(&conn_id).cloned()
-                };
-                if let Some(tx) = tx {
-                    let _ = tx.send(TunnelEvent::Data(data)).await;
-                }
+                self.dispatch_event(conn_id, TunnelEvent::Data(data)).await;
             }
             Message::Close { conn_id } => {
                 debug!("[{}] SSE close", conn_id);
-                let tx = {
-                    let channels = self.response_channels.lock().await;
-                    channels.get(&conn_id).cloned()
-                };
-                if let Some(tx) = tx {
-                    let _ = tx.send(TunnelEvent::Close).await;
-                }
+                self.dispatch_event(conn_id, TunnelEvent::Close).await;
             }
             Message::Error { conn_id, message } => {
                 warn!("[{:?}] SSE error: {}", conn_id, message);
                 if let Some(cid) = conn_id {
-                    let tx = {
-                        let channels = self.response_channels.lock().await;
-                        channels.get(&cid).cloned()
-                    };
-                    if let Some(tx) = tx {
-                        let _ = tx.send(TunnelEvent::Error(message)).await;
-                    }
+                    self.dispatch_event(cid, TunnelEvent::Error(message)).await;
                 }
             }
             Message::ExitStatus { conn_id, code } => {
                 debug!("[{}] SSE exit status {}", conn_id, code);
-                let tx = {
-                    let channels = self.response_channels.lock().await;
-                    channels.get(&conn_id).cloned()
-                };
-                if let Some(tx) = tx {
-                    let _ = tx.send(TunnelEvent::Exit(code)).await;
-                }
+                self.dispatch_event(conn_id, TunnelEvent::Exit(code)).await;
             }
             Message::Reset => {
                 // Server signalled the session was freshly created (e.g. it
@@ -399,8 +381,40 @@ impl Tunnel {
     }
 
     /// Register a connection and return event receiver
+    /// Hand one event to a registered connection. Unknown conn_ids are a silent
+    /// no-op (the relay may already have torn down).
+    ///
+    /// Every connection is fed from a single dispatch loop, so this must never
+    /// wait indefinitely: a consumer that has stopped reading fills its queue,
+    /// and an unbounded send would then starve every other connection on the
+    /// tunnel. A connection that makes no progress within
+    /// `DISPATCH_STALL_TIMEOUT` is dropped instead — closing its channel ends
+    /// its relay, which closes the local socket so the app sees the failure.
+    /// Note this bounds the stall, not the latency: dispatch can still be held
+    /// up for one timeout by a consumer that stops reading.
+    async fn dispatch_event(&self, conn_id: u32, event: TunnelEvent) {
+        // Clone the sender out of the guard before awaiting: holding the mutex
+        // across send() would block session ops and every other dispatch too.
+        let tx = {
+            let channels = self.response_channels.lock().await;
+            channels.get(&conn_id).cloned()
+        };
+        let Some(tx) = tx else { return };
+
+        if tokio::time::timeout(DISPATCH_STALL_TIMEOUT, tx.send(event))
+            .await
+            .is_err()
+        {
+            warn!(
+                "[{}] consumer stalled for {:?}; dropping the connection to keep the tunnel moving",
+                conn_id, DISPATCH_STALL_TIMEOUT
+            );
+            self.unregister_connection(conn_id).await;
+        }
+    }
+
     pub async fn register_connection(&self, conn_id: u32) -> mpsc::Receiver<TunnelEvent> {
-        let (tx, rx) = mpsc::channel(256);
+        let (tx, rx) = mpsc::channel(CONN_CHANNEL_CAPACITY);
         let mut channels = self.response_channels.lock().await;
         channels.insert(conn_id, tx);
         rx
@@ -516,5 +530,44 @@ mod tests {
         tunnel.handle_sse_message(&frame).await;
 
         assert!(rx.try_recv().is_err(), "nothing should have been delivered");
+    }
+
+    /// One connection whose consumer has stopped reading must not wedge the
+    /// shared dispatch loop: its channel fills, and an unbounded send there
+    /// parks forever, starving every other connection on the tunnel.
+    /// Time is paused, so the stall timeout elapses without a real wait.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_consumer_cannot_wedge_the_dispatch_loop() {
+        let tunnel = test_tunnel("pw");
+        // Held but never drained: this is the stalled local app.
+        let _stalled = tunnel.register_connection(1).await;
+        let mut healthy = tunnel.register_connection(2).await;
+
+        // Fill the stalled connection's channel to capacity.
+        let stalled_frame = sse_frame(&tunnel, &Message::Data { conn_id: 1, data: vec![0u8; 8] });
+        for _ in 0..CONN_CHANNEL_CAPACITY {
+            tunnel.handle_sse_message(&stalled_frame).await;
+        }
+
+        // The next send has nowhere to go. It must give up rather than park.
+        tokio::time::timeout(Duration::from_secs(600), tunnel.handle_sse_message(&stalled_frame))
+            .await
+            .expect("dispatch loop parked on a full channel");
+
+        // A wedged connection gets dropped, not carried forever.
+        assert!(
+            !tunnel.response_channels.lock().await.contains_key(&1),
+            "stalled connection should have been torn down"
+        );
+
+        // The whole point: other connections still get served.
+        let healthy_frame = sse_frame(&tunnel, &Message::Data { conn_id: 2, data: b"fine".to_vec() });
+        tokio::time::timeout(Duration::from_secs(600), tunnel.handle_sse_message(&healthy_frame))
+            .await
+            .expect("dispatch to a healthy connection was blocked");
+        match healthy.try_recv() {
+            Ok(TunnelEvent::Data(d)) => assert_eq!(d, b"fine"),
+            other => panic!("expected Data on the healthy conn, got {:?}", other),
+        }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,19 @@
+//! Helpers shared by the integration test crates.
+//!
+//! Files under `tests/` are each compiled as their own test binary, but a
+//! subdirectory module like this one is not, so it is the standard place to
+//! put code common to several of them.
+
+use std::process::Command;
+
+/// The tests all talk over loopback, so an ambient proxy in the developer's
+/// environment must not be inherited: the HTTP client honours `*_PROXY` and
+/// would try to reach 127.0.0.1 through it.
+///
+/// Shared rather than copied per crate so a new variable, or a rename, is one
+/// edit instead of three.
+pub fn no_inherited_proxy(cmd: &mut Command) {
+    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
+        cmd.env_remove(var);
+    }
+}

--- a/tests/reconnect_on_url_change.rs
+++ b/tests/reconnect_on_url_change.rs
@@ -5,6 +5,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod common;
+use crate::common::no_inherited_proxy;
+
 /// Find an available TCP port on localhost
 fn find_free_port() -> u16 {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind");
@@ -72,15 +75,6 @@ password = ""
 "#,
     );
     std::fs::write(config_path, content).expect("failed to write config");
-}
-
-/// Everything here talks over loopback, so an ambient proxy in the developer's
-/// environment must not be inherited: the HTTP client honours `*_PROXY` and
-/// would try to reach 127.0.0.1 through it.
-fn no_inherited_proxy(cmd: &mut Command) {
-    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
-        cmd.env_remove(var);
-    }
 }
 
 /// Wraps a Child process and kills it on drop

--- a/tests/reconnect_on_url_change.rs
+++ b/tests/reconnect_on_url_change.rs
@@ -74,6 +74,15 @@ password = ""
     std::fs::write(config_path, content).expect("failed to write config");
 }
 
+/// Everything here talks over loopback, so an ambient proxy in the developer's
+/// environment must not be inherited: the HTTP client honours `*_PROXY` and
+/// would try to reach 127.0.0.1 through it.
+fn no_inherited_proxy(cmd: &mut Command) {
+    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
+        cmd.env_remove(var);
+    }
+}
+
 /// Wraps a Child process and kills it on drop
 struct KillOnDrop(Child);
 
@@ -95,6 +104,12 @@ fn test_client_reconnects_on_server_url_change() {
 
     let config_path = tmp.join("config.toml");
     let log_path = tmp.join("client.log");
+    // The server falls back to ./config.toml and then ~/.config/tunnix/
+    // config.toml when no --config is given, so point it at an empty file in
+    // the test's own directory: an ambient path_prefix would otherwise change
+    // what this test is exercising.
+    let server_config = tmp.join("server.toml");
+    std::fs::write(&server_config, "[server]\n").expect("write server config");
 
     // Find ports
     let port_a = find_free_port();
@@ -110,42 +125,50 @@ fn test_client_reconnects_on_server_url_change() {
 
     write_config(&config_path, port_a, proxy_port);
 
-    let _server_a = KillOnDrop(
-        Command::new(bin)
-            .args([
-                "server",
-                "--listen",
-                &format!("127.0.0.1:{}", port_a),
-                "-p",
-                "test",
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to start server A"),
-    );
+    let _server_a = {
+        let mut cmd = Command::new(bin);
+        cmd.args([
+            "server",
+            "--config",
+            server_config.to_str().unwrap(),
+            "--listen",
+            &format!("127.0.0.1:{}", port_a),
+            "-p",
+            "test",
+        ]);
+        no_inherited_proxy(&mut cmd);
+        KillOnDrop(
+            cmd.stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start server A"),
+        )
+    };
 
     assert!(
         wait_for_server(port_a, 10_000),
         "server A did not become ready"
     );
 
-    let _client = KillOnDrop(
-        Command::new(bin)
-            .args([
-                "client",
-                "--config",
-                config_path.to_str().unwrap(),
-                "--log",
-                log_path.to_str().unwrap(),
-                "-p",
-                "test",
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to start client"),
-    );
+    let _client = {
+        let mut cmd = Command::new(bin);
+        cmd.args([
+            "client",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--log",
+            log_path.to_str().unwrap(),
+            "-p",
+            "test",
+        ]);
+        no_inherited_proxy(&mut cmd);
+        KillOnDrop(
+            cmd.stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start client"),
+        )
+    };
 
     assert!(
         wait_for_log(&log_path, "Tunnel established", 15_000),
@@ -161,20 +184,25 @@ fn test_client_reconnects_on_server_url_change() {
 
     // --- Phase 2: Switch to server B ---
 
-    let _server_b = KillOnDrop(
-        Command::new(bin)
-            .args([
-                "server",
-                "--listen",
-                &format!("127.0.0.1:{}", port_b),
-                "-p",
-                "test",
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to start server B"),
-    );
+    let _server_b = {
+        let mut cmd = Command::new(bin);
+        cmd.args([
+            "server",
+            "--config",
+            server_config.to_str().unwrap(),
+            "--listen",
+            &format!("127.0.0.1:{}", port_b),
+            "-p",
+            "test",
+        ]);
+        no_inherited_proxy(&mut cmd);
+        KillOnDrop(
+            cmd.stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start server B"),
+        )
+    };
 
     assert!(
         wait_for_server(port_b, 10_000),

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -12,6 +12,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod common;
+use crate::common::no_inherited_proxy;
+
 const RESPONSE_LEN: usize = 256 * 1024;
 const UPLOAD_LEN: usize = 16 * 1024 * 1024;
 
@@ -87,15 +90,11 @@ impl Drop for KillOnDrop {
     }
 }
 
-/// Everything here talks over loopback, so an ambient proxy in the developer's
-/// environment must not be inherited: the HTTP client honours `*_PROXY` and
-/// would try to reach 127.0.0.1 through it.
+/// Spawn tunnix without inheriting an ambient proxy - see `common`.
 fn spawn_direct(bin: &str, args: &[&str]) -> KillOnDrop {
     let mut cmd = Command::new(bin);
     cmd.args(args);
-    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
-        cmd.env_remove(var);
-    }
+    no_inherited_proxy(&mut cmd);
     KillOnDrop(
         cmd.stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -192,6 +192,13 @@ fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
     let mut sock = TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5))
         .expect("failed to connect to proxy");
     sock.set_read_timeout(Some(Duration::from_secs(30))).unwrap();
+    // Bound writes too, not just reads. `test_upload_survives_target_output_eof`
+    // pushes UPLOAD_LEN through this socket, so a relay that stops draining its
+    // read half without closing the connection fills the socket buffer and
+    // parks `write_all` forever - a hung test run rather than a failed one,
+    // since cargo bounds neither. Applies per write syscall, so this trips only
+    // when the relay makes no progress at all for 30s.
+    sock.set_write_timeout(Some(Duration::from_secs(30))).unwrap();
 
     sock.write_all(&[0x05, 0x01, 0x00]).expect("greeting failed");
     let mut greeting = [0u8; 2];

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -144,6 +144,39 @@ fn spawn_read_after_own_eof_target() -> (u16, std::sync::mpsc::Receiver<usize>) 
     (port, report_rx)
 }
 
+/// Target that sends a partial response and then aborts the connection with a
+/// RST, the way a crashing or resetting upstream does. The proxied client must
+/// not be told this ended cleanly.
+#[cfg(unix)]
+fn spawn_reset_midstream_target() -> u16 {
+    use std::os::fd::AsRawFd;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind target");
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        for conn in listener.incoming() {
+            let Ok(mut sock) = conn else { continue };
+            let _ = sock.write_all(b"partial");
+            let _ = sock.flush();
+
+            // SO_LINGER with a zero timeout turns close() into a RST instead of
+            // a FIN, so the peer sees a failure rather than end-of-stream.
+            let linger = libc::linger { l_onoff: 1, l_linger: 0 };
+            unsafe {
+                libc::setsockopt(
+                    sock.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_LINGER,
+                    &linger as *const _ as *const libc::c_void,
+                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                );
+            }
+            drop(sock);
+        }
+    });
+    port
+}
+
 /// SOCKS5 no-auth handshake + CONNECT to 127.0.0.1:`port`.
 fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
     let addr = format!("127.0.0.1:{}", proxy_port);
@@ -286,5 +319,44 @@ fn test_upload_survives_target_output_eof() {
         total, UPLOAD_LEN,
         "upload truncated after target output EOF: target got {} of {} bytes",
         total, UPLOAD_LEN
+    );
+}
+
+/// A target that fails mid-response must not look like one that finished. The
+/// relay reported both as `Close`, so the proxied app saw a clean EOF on a
+/// truncated stream and had no way to tell the difference.
+#[cfg(unix)]
+#[test]
+fn test_target_failure_is_not_a_clean_eof() {
+    let tunnel = start_tunnel("target_reset");
+    let target_port = spawn_reset_midstream_target();
+
+    let mut sock = socks5_connect(tunnel.proxy_port, target_port);
+    sock.write_all(b"go").expect("request write failed");
+    sock.flush().unwrap();
+
+    // Reading to the end must fail, not succeed: the response was truncated by
+    // the target's reset. Whether the partial bytes land first is a race, so
+    // assert only on the property that matters.
+    let mut got = Vec::new();
+    let result = sock.read_to_end(&mut got);
+
+    let err = match result {
+        Ok(_) => panic!(
+            "truncated response was reported as a clean EOF after {} byte(s)",
+            got.len()
+        ),
+        Err(e) => e,
+    };
+    // The failure has to come from the connection being reset, not from this
+    // socket's own read timeout: a relay that simply stalls would otherwise
+    // look identical to one that correctly signalled the failure.
+    assert!(
+        !matches!(
+            err.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ),
+        "read timed out instead of the connection being reset: {:?}",
+        err
     );
 }

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -1,0 +1,211 @@
+//! Half-close semantics through the SOCKS5 relay.
+//!
+//! A client that finishes sending (shutdown(WR)) must still receive the full
+//! response. The relay used to tear the response direction down as soon as the
+//! upload direction hit EOF, so the reply was silently truncated or lost.
+
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const RESPONSE_LEN: usize = 256 * 1024;
+
+fn find_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+    listener.local_addr().unwrap().port()
+}
+
+fn health_check(port: u16) -> bool {
+    let addr = format!("127.0.0.1:{}", port);
+    if let Ok(mut stream) = TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(1)) {
+        let req = "GET /health HTTP/1.0\r\n\r\n";
+        let _ = stream.write_all(req.as_bytes());
+        let mut resp = String::new();
+        if stream.read_to_string(&mut resp).is_ok() {
+            return resp.contains("200 OK");
+        }
+    }
+    false
+}
+
+fn wait_for_server(port: u16, timeout_ms: u64) -> bool {
+    let start = Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        if health_check(port) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+fn wait_for_log(log_path: &Path, target: &str, timeout_ms: u64) -> bool {
+    let start = Instant::now();
+    let mut buf = String::new();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        buf.clear();
+        if let Ok(mut f) = std::fs::File::open(log_path) {
+            if f.read_to_string(&mut buf).is_ok() && buf.contains(target) {
+                return true;
+            }
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+fn write_config(config_path: &Path, server_port: u16, proxy_port: u16) {
+    let content = format!(
+        r#"[client]
+server_url = "http://127.0.0.1:{server_port}"
+local_addr = "127.0.0.1:{proxy_port}"
+password = ""
+"#,
+    );
+    std::fs::write(config_path, content).expect("failed to write config");
+}
+
+struct KillOnDrop(Child);
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Everything here talks over loopback, so an ambient proxy in the developer's
+/// environment must not be inherited: the HTTP client honours `*_PROXY` and
+/// would try to reach 127.0.0.1 through it.
+fn spawn_direct(bin: &str, args: &[&str]) -> KillOnDrop {
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
+        cmd.env_remove(var);
+    }
+    KillOnDrop(
+        cmd.stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn tunnix"),
+    )
+}
+
+/// Target that only answers *after* it has seen the client's FIN: it reads to
+/// EOF, then writes `RESPONSE_LEN` bytes. Any relay that collapses both
+/// directions on upload EOF will never deliver this payload.
+fn spawn_reply_after_eof_target() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind target");
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        for conn in listener.incoming() {
+            let Ok(mut sock) = conn else { continue };
+            let mut request = Vec::new();
+            // Read to EOF: returns only once the proxied client half-closed.
+            if sock.read_to_end(&mut request).is_err() {
+                continue;
+            }
+            let payload: Vec<u8> = (0..RESPONSE_LEN).map(|i| (i % 251) as u8).collect();
+            let _ = sock.write_all(&payload);
+            let _ = sock.flush();
+            let _ = sock.shutdown(Shutdown::Write);
+        }
+    });
+    port
+}
+
+/// SOCKS5 no-auth handshake + CONNECT to 127.0.0.1:`port`.
+fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
+    let addr = format!("127.0.0.1:{}", proxy_port);
+    let mut sock = TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5))
+        .expect("failed to connect to proxy");
+    sock.set_read_timeout(Some(Duration::from_secs(30))).unwrap();
+
+    sock.write_all(&[0x05, 0x01, 0x00]).expect("greeting failed");
+    let mut greeting = [0u8; 2];
+    sock.read_exact(&mut greeting).expect("no auth reply");
+    assert_eq!(greeting, [0x05, 0x00], "unexpected SOCKS5 auth reply");
+
+    let mut req = vec![0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1];
+    req.extend_from_slice(&port.to_be_bytes());
+    sock.write_all(&req).expect("connect request failed");
+
+    let mut reply = [0u8; 10];
+    sock.read_exact(&mut reply).expect("no connect reply");
+    assert_eq!(reply[0], 0x05, "unexpected SOCKS5 version in reply");
+    assert_eq!(reply[1], 0x00, "SOCKS5 CONNECT was refused");
+
+    sock
+}
+
+#[test]
+fn test_response_survives_client_half_close() {
+    let bin = std::env!("CARGO_BIN_EXE_tunnix");
+
+    let tmp = std::env::temp_dir().join(format!("tunnix_half_close_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+    let config_path = tmp.join("config.toml");
+    let log_path = tmp.join("client.log");
+
+    let server_port = find_free_port();
+    let proxy_port = find_free_port();
+    let target_port = spawn_reply_after_eof_target();
+
+    write_config(&config_path, server_port, proxy_port);
+
+    let _server = spawn_direct(
+        bin,
+        &[
+            "server",
+            "--listen",
+            &format!("127.0.0.1:{}", server_port),
+            "-p",
+            "test",
+        ],
+    );
+    assert!(wait_for_server(server_port, 10_000), "server did not become ready");
+
+    let _client = spawn_direct(
+        bin,
+        &[
+            "client",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--log",
+            log_path.to_str().unwrap(),
+            "-p",
+            "test",
+        ],
+    );
+    assert!(
+        wait_for_log(&log_path, "Tunnel established", 15_000),
+        "client did not establish tunnel"
+    );
+
+    let mut sock = socks5_connect(proxy_port, target_port);
+
+    // Send a request, then half-close: we are done sending, but still expect
+    // the whole reply back.
+    sock.write_all(b"ping").expect("request write failed");
+    sock.flush().unwrap();
+    sock.shutdown(Shutdown::Write).expect("half-close failed");
+
+    let mut got = Vec::new();
+    sock.read_to_end(&mut got).expect("response read failed");
+
+    assert_eq!(
+        got.len(),
+        RESPONSE_LEN,
+        "response truncated after half-close: got {} of {} bytes",
+        got.len(),
+        RESPONSE_LEN
+    );
+    let expected: Vec<u8> = (0..RESPONSE_LEN).map(|i| (i % 251) as u8).collect();
+    assert_eq!(got, expected, "response payload corrupted");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -186,6 +186,26 @@ fn spawn_reset_midstream_target() -> u16 {
     port
 }
 
+/// Target that streams until its socket fails, then reports how long it kept
+/// writing. A relay that treats a client abort as a mere half-close leaves the
+/// server pulling this until the cap below.
+fn spawn_endless_target() -> (u16, std::sync::mpsc::Receiver<Duration>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind target");
+    let port = listener.local_addr().unwrap().port();
+    let (report_tx, report_rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        for conn in listener.incoming() {
+            let Ok(mut sock) = conn else { continue };
+            let chunk = vec![7u8; 65536];
+            let started = Instant::now();
+            // Capped so a regression fails the assertion instead of hanging.
+            while started.elapsed() < Duration::from_secs(20) && sock.write_all(&chunk).is_ok() {}
+            let _ = report_tx.send(started.elapsed());
+        }
+    });
+    (port, report_rx)
+}
+
 /// SOCKS5 no-auth handshake + CONNECT to 127.0.0.1:`port`.
 fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
     let addr = format!("127.0.0.1:{}", proxy_port);
@@ -384,5 +404,49 @@ fn test_target_failure_is_not_a_clean_eof() {
         ),
         "read timed out instead of the connection being reset: {:?}",
         err
+    );
+}
+
+/// An app that *aborts* - as opposed to half-closing - must release the target
+/// on the server, not just the upload direction. `Close` only half-closes,
+/// which is right for an app that finished sending and still wants its reply,
+/// so a relay that sent `Close` on abort too left the server pulling the whole
+/// remaining response into a conn_id the client had already forgotten: a
+/// cancelled download was downloaded anyway, in full, to nobody.
+#[cfg(unix)]
+#[test]
+fn test_client_abort_releases_the_target() {
+    use std::os::fd::AsRawFd;
+
+    let tunnel = start_tunnel("client_abort");
+    let (target_port, released) = spawn_endless_target();
+
+    let mut sock = socks5_connect(tunnel.proxy_port, target_port);
+
+    // Let the response get going, then abort. SO_LINGER with a zero timeout
+    // turns close() into a RST, the way a crashed or cancelled app leaves a
+    // connection.
+    let mut buf = vec![0u8; 4096];
+    let n = sock.read(&mut buf).expect("no response bytes arrived");
+    assert!(n > 0, "target sent nothing");
+    let linger = libc::linger { l_onoff: 1, l_linger: 0 };
+    unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            &linger as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        );
+    }
+    drop(sock);
+
+    let held_for = released
+        .recv_timeout(Duration::from_secs(40))
+        .expect("target never reported: its socket was never released");
+    assert!(
+        held_for < Duration::from_secs(10),
+        "server kept pulling the target for {:?} after the client aborted",
+        held_for
     );
 }

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -15,14 +15,19 @@ use std::time::{Duration, Instant};
 const RESPONSE_LEN: usize = 256 * 1024;
 const UPLOAD_LEN: usize = 16 * 1024 * 1024;
 
+/// Ask the OS for an unused localhost port.
 fn find_free_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
     listener.local_addr().unwrap().port()
 }
 
+/// Perform a raw GET /health and check for 200.
 fn health_check(port: u16) -> bool {
     let addr = format!("127.0.0.1:{}", port);
     if let Ok(mut stream) = TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(1)) {
+        // Bound the read: a socket that accepts and then says nothing would
+        // otherwise hang the poll loop instead of failing this attempt.
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
         let req = "GET /health HTTP/1.0\r\n\r\n";
         let _ = stream.write_all(req.as_bytes());
         let mut resp = String::new();
@@ -33,6 +38,7 @@ fn health_check(port: u16) -> bool {
     false
 }
 
+/// Poll the health endpoint until the server answers or the timeout expires.
 fn wait_for_server(port: u16, timeout_ms: u64) -> bool {
     let start = Instant::now();
     while start.elapsed().as_millis() < timeout_ms as u128 {
@@ -44,6 +50,7 @@ fn wait_for_server(port: u16, timeout_ms: u64) -> bool {
     false
 }
 
+/// Wait for a substring to appear in a log file.
 fn wait_for_log(log_path: &Path, target: &str, timeout_ms: u64) -> bool {
     let start = Instant::now();
     let mut buf = String::new();
@@ -59,6 +66,7 @@ fn wait_for_log(log_path: &Path, target: &str, timeout_ms: u64) -> bool {
     false
 }
 
+/// Write a minimal client config pointing at the given server and proxy ports.
 fn write_config(config_path: &Path, server_port: u16, proxy_port: u16) {
     let content = format!(
         r#"[client]
@@ -70,6 +78,7 @@ password = ""
     std::fs::write(config_path, content).expect("failed to write config");
 }
 
+/// Wraps a child process and kills it on drop.
 struct KillOnDrop(Child);
 impl Drop for KillOnDrop {
     fn drop(&mut self) {
@@ -216,6 +225,7 @@ impl Drop for Tunnel {
     }
 }
 
+/// Start a server and client pair and wait until the tunnel is established.
 fn start_tunnel(name: &str) -> Tunnel {
     let bin = std::env!("CARGO_BIN_EXE_tunnix");
 
@@ -230,10 +240,19 @@ fn start_tunnel(name: &str) -> Tunnel {
     let proxy_port = find_free_port();
     write_config(&config_path, server_port, proxy_port);
 
+    // The server falls back to ./config.toml and then ~/.config/tunnix/
+    // config.toml when no --config is given, so point it at an empty file
+    // in the test's own directory: an ambient path_prefix or allow_exec would
+    // otherwise change what these tests are exercising.
+    let server_config = tmp.join("server.toml");
+    std::fs::write(&server_config, "[server]\n").expect("write server config");
+
     let server = spawn_direct(
         bin,
         &[
             "server",
+            "--config",
+            server_config.to_str().unwrap(),
             "--listen",
             &format!("127.0.0.1:{}", server_port),
             "-p",

--- a/tests/relay_half_close.rs
+++ b/tests/relay_half_close.rs
@@ -1,8 +1,9 @@
-//! Half-close semantics through the SOCKS5 relay.
+//! Half-close semantics through the SOCKS5 relay, in both directions.
 //!
-//! A client that finishes sending (shutdown(WR)) must still receive the full
-//! response. The relay used to tear the response direction down as soon as the
-//! upload direction hit EOF, so the reply was silently truncated or lost.
+//! Each direction of a proxied connection must end on its own. The relay used
+//! to collapse both as soon as either one finished: a client that half-closed
+//! after its request lost the response, and a target that finished sending
+//! first had the rest of the client's upload silently discarded.
 
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
@@ -12,6 +13,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const RESPONSE_LEN: usize = 256 * 1024;
+const UPLOAD_LEN: usize = 16 * 1024 * 1024;
 
 fn find_free_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind");
@@ -116,6 +118,32 @@ fn spawn_reply_after_eof_target() -> u16 {
     port
 }
 
+/// Target that closes its *output* first, then keeps reading: it writes a short
+/// greeting, half-closes, and reports how many bytes it received afterwards.
+/// A relay that drops the target writer on output EOF loses the whole upload.
+fn spawn_read_after_own_eof_target() -> (u16, std::sync::mpsc::Receiver<usize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind target");
+    let port = listener.local_addr().unwrap().port();
+    let (report_tx, report_rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        for conn in listener.incoming() {
+            let Ok(mut sock) = conn else { continue };
+            let _ = sock.write_all(b"hi");
+            let _ = sock.flush();
+            // Our output is done; the peer may still be uploading.
+            let _ = sock.shutdown(Shutdown::Write);
+
+            let mut sink = Vec::new();
+            let received = match sock.read_to_end(&mut sink) {
+                Ok(n) => n,
+                Err(_) => sink.len(),
+            };
+            let _ = report_tx.send(received);
+        }
+    });
+    (port, report_rx)
+}
+
 /// SOCKS5 no-auth handshake + CONNECT to 127.0.0.1:`port`.
 fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
     let addr = format!("127.0.0.1:{}", proxy_port);
@@ -140,11 +168,25 @@ fn socks5_connect(proxy_port: u16, port: u16) -> TcpStream {
     sock
 }
 
-#[test]
-fn test_response_survives_client_half_close() {
+/// A running server + client pair with an established tunnel. Both processes
+/// are killed when this is dropped.
+struct Tunnel {
+    proxy_port: u16,
+    tmp: std::path::PathBuf,
+    _server: KillOnDrop,
+    _client: KillOnDrop,
+}
+
+impl Drop for Tunnel {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.tmp);
+    }
+}
+
+fn start_tunnel(name: &str) -> Tunnel {
     let bin = std::env!("CARGO_BIN_EXE_tunnix");
 
-    let tmp = std::env::temp_dir().join(format!("tunnix_half_close_{}", std::process::id()));
+    let tmp = std::env::temp_dir().join(format!("tunnix_{}_{}", name, std::process::id()));
     let _ = std::fs::remove_dir_all(&tmp);
     std::fs::create_dir_all(&tmp).expect("create temp dir");
 
@@ -153,11 +195,9 @@ fn test_response_survives_client_half_close() {
 
     let server_port = find_free_port();
     let proxy_port = find_free_port();
-    let target_port = spawn_reply_after_eof_target();
-
     write_config(&config_path, server_port, proxy_port);
 
-    let _server = spawn_direct(
+    let server = spawn_direct(
         bin,
         &[
             "server",
@@ -169,7 +209,7 @@ fn test_response_survives_client_half_close() {
     );
     assert!(wait_for_server(server_port, 10_000), "server did not become ready");
 
-    let _client = spawn_direct(
+    let client = spawn_direct(
         bin,
         &[
             "client",
@@ -186,7 +226,15 @@ fn test_response_survives_client_half_close() {
         "client did not establish tunnel"
     );
 
-    let mut sock = socks5_connect(proxy_port, target_port);
+    Tunnel { proxy_port, tmp, _server: server, _client: client }
+}
+
+#[test]
+fn test_response_survives_client_half_close() {
+    let tunnel = start_tunnel("half_close");
+    let target_port = spawn_reply_after_eof_target();
+
+    let mut sock = socks5_connect(tunnel.proxy_port, target_port);
 
     // Send a request, then half-close: we are done sending, but still expect
     // the whole reply back.
@@ -206,6 +254,37 @@ fn test_response_survives_client_half_close() {
     );
     let expected: Vec<u8> = (0..RESPONSE_LEN).map(|i| (i % 251) as u8).collect();
     assert_eq!(got, expected, "response payload corrupted");
+}
 
-    let _ = std::fs::remove_dir_all(&tmp);
+/// The mirror direction: the *target* finishes sending first, and the upload
+/// still in progress must keep flowing. The server used to drop the target's
+/// writer as soon as target output hit EOF, so everything sent afterwards was
+/// silently discarded.
+#[test]
+fn test_upload_survives_target_output_eof() {
+    let tunnel = start_tunnel("upload_after_eof");
+    let (target_port, received) = spawn_read_after_own_eof_target();
+
+    let mut sock = socks5_connect(tunnel.proxy_port, target_port);
+
+    // Drain the response direction to EOF: the target has half-closed, so the
+    // relay should deliver its greeting and then close only this direction.
+    let mut greeting = Vec::new();
+    sock.read_to_end(&mut greeting).expect("greeting read failed");
+    assert_eq!(greeting, b"hi", "unexpected greeting from target");
+
+    // Response direction is done. The upload direction must still work.
+    let payload: Vec<u8> = (0..UPLOAD_LEN).map(|i| (i % 251) as u8).collect();
+    sock.write_all(&payload).expect("upload failed");
+    sock.flush().unwrap();
+    sock.shutdown(Shutdown::Write).expect("upload half-close failed");
+
+    let total = received
+        .recv_timeout(Duration::from_secs(60))
+        .expect("target never reported a byte count");
+    assert_eq!(
+        total, UPLOAD_LEN,
+        "upload truncated after target output EOF: target got {} of {} bytes",
+        total, UPLOAD_LEN
+    );
 }

--- a/tests/transfer_roundtrip.rs
+++ b/tests/transfer_roundtrip.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -41,8 +42,30 @@ impl Drop for KillOnDrop {
     }
 }
 
-fn start_server(bin: &str, port: u16, allow_transfer: bool) -> KillOnDrop {
+/// Everything here talks over loopback, so an ambient proxy in the developer's
+/// environment must not be inherited: the HTTP client honours `*_PROXY` and
+/// would try to reach 127.0.0.1 through it.
+fn no_inherited_proxy(cmd: &mut Command) {
+    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
+        cmd.env_remove(var);
+    }
+}
+
+/// Write an empty config for a spawned process to use. Without `--config` the
+/// binary falls back to ./config.toml and then ~/.config/tunnix/config.toml, so
+/// a developer's own `allow_transfer = true` would silently decide what these
+/// tests are actually exercising.
+fn write_empty_config(tmp: &Path, name: &str, section: &str) -> std::path::PathBuf {
+    let path = tmp.join(name);
+    std::fs::write(&path, format!("[{}]\n", section)).expect("write config");
+    path
+}
+
+fn start_server(bin: &str, tmp: &Path, port: u16, allow_transfer: bool) -> KillOnDrop {
+    let config = write_empty_config(tmp, "server.toml", "server");
     let mut args = vec![
+        "--config".to_string(),
+        config.to_str().unwrap().to_string(),
         "server".to_string(),
         "--listen".to_string(),
         format!("127.0.0.1:{}", port),
@@ -52,10 +75,11 @@ fn start_server(bin: &str, port: u16, allow_transfer: bool) -> KillOnDrop {
     if allow_transfer {
         args.push("--allow-transfer".to_string());
     }
+    let mut cmd = Command::new(bin);
+    cmd.args(&args);
+    no_inherited_proxy(&mut cmd);
     KillOnDrop(
-        Command::new(bin)
-            .args(&args)
-            .stdout(Stdio::null())
+        cmd.stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .expect("failed to start server"),
@@ -64,8 +88,11 @@ fn start_server(bin: &str, port: u16, allow_transfer: bool) -> KillOnDrop {
 
 /// Run `tunnix push|pull <paths...>` and return whether it exited successfully.
 /// `paths` is the cp-style source(s)... + destination tail.
-fn run_transfer(bin: &str, port: u16, sub: &str, paths: &[&str]) -> bool {
+fn run_transfer(bin: &str, tmp: &Path, port: u16, sub: &str, paths: &[&str]) -> bool {
+    let config = write_empty_config(tmp, "client.toml", "client");
     let mut args = vec![
+        "--config".to_string(),
+        config.to_str().unwrap().to_string(),
         sub.to_string(),
         "-s".to_string(),
         format!("http://127.0.0.1:{}", port),
@@ -73,9 +100,10 @@ fn run_transfer(bin: &str, port: u16, sub: &str, paths: &[&str]) -> bool {
         "test".to_string(),
     ];
     args.extend(paths.iter().map(|s| s.to_string()));
-    Command::new(bin)
-        .args(&args)
-        .stdout(Stdio::null())
+    let mut cmd = Command::new(bin);
+    cmd.args(&args);
+    no_inherited_proxy(&mut cmd);
+    cmd.stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .expect("failed to run transfer")
@@ -98,13 +126,13 @@ fn test_push_pull_roundtrip() {
     std::fs::write(src.join("nested/big.bin"), &big).unwrap();
 
     let port = find_free_port();
-    let _server = start_server(bin, port, true);
+    let _server = start_server(bin, &tmp, port, true);
     assert!(wait_for_server(port, 10_000), "server did not become ready");
 
     // --- push: src -> server-side `remote/` (unpacks to remote/src/...) ---
     let remote = tmp.join("remote");
     assert!(
-        run_transfer(bin, port, "push", &[src.to_str().unwrap(), remote.to_str().unwrap()]),
+        run_transfer(bin, &tmp, port, "push", &[src.to_str().unwrap(), remote.to_str().unwrap()]),
         "push failed"
     );
     assert_eq!(
@@ -117,7 +145,7 @@ fn test_push_pull_roundtrip() {
     let pulled = tmp.join("pulled");
     let remote_src = remote.join("src");
     assert!(
-        run_transfer(bin, port, "pull", &[remote_src.to_str().unwrap(), pulled.to_str().unwrap()]),
+        run_transfer(bin, &tmp, port, "pull", &[remote_src.to_str().unwrap(), pulled.to_str().unwrap()]),
         "pull failed"
     );
     assert_eq!(
@@ -145,7 +173,7 @@ fn test_push_pull_multiple_sources() {
     std::fs::write(dir.join("inner.txt"), b"nested").unwrap();
 
     let port = find_free_port();
-    let _server = start_server(bin, port, true);
+    let _server = start_server(bin, &tmp, port, true);
     assert!(wait_for_server(port, 10_000), "server did not become ready");
 
     // push one.txt two.txt dir/ -> remote/  (last arg is the dest)
@@ -153,6 +181,7 @@ fn test_push_pull_multiple_sources() {
     assert!(
         run_transfer(
             bin,
+            &tmp,
             port,
             "push",
             &[
@@ -173,6 +202,7 @@ fn test_push_pull_multiple_sources() {
     assert!(
         run_transfer(
             bin,
+            &tmp,
             port,
             "pull",
             &[
@@ -203,16 +233,16 @@ fn test_transfer_denied_when_disabled() {
     std::fs::write(src.join("a.txt"), b"nope").unwrap();
 
     let port = find_free_port();
-    let _server = start_server(bin, port, false); // allow_transfer OFF
+    let _server = start_server(bin, &tmp, port, false); // allow_transfer OFF
     assert!(wait_for_server(port, 10_000), "server did not become ready");
 
     let remote = tmp.join("remote");
     assert!(
-        !run_transfer(bin, port, "push", &[src.to_str().unwrap(), remote.to_str().unwrap()]),
+        !run_transfer(bin, &tmp, port, "push", &[src.to_str().unwrap(), remote.to_str().unwrap()]),
         "push should fail when transfers are disabled"
     );
     assert!(
-        !run_transfer(bin, port, "pull", &[remote.to_str().unwrap(), tmp.join("pulled").to_str().unwrap()]),
+        !run_transfer(bin, &tmp, port, "pull", &[remote.to_str().unwrap(), tmp.join("pulled").to_str().unwrap()]),
         "pull should fail when transfers are disabled"
     );
 

--- a/tests/transfer_roundtrip.rs
+++ b/tests/transfer_roundtrip.rs
@@ -5,6 +5,9 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod common;
+use crate::common::no_inherited_proxy;
+
 fn find_free_port() -> u16 {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind");
     listener.local_addr().unwrap().port()
@@ -42,15 +45,6 @@ impl Drop for KillOnDrop {
     }
 }
 
-/// Everything here talks over loopback, so an ambient proxy in the developer's
-/// environment must not be inherited: the HTTP client honours `*_PROXY` and
-/// would try to reach 127.0.0.1 through it.
-fn no_inherited_proxy(cmd: &mut Command) {
-    for var in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] {
-        cmd.env_remove(var);
-    }
-}
-
 /// Write an empty config for a spawned process to use. Without `--config` the
 /// binary falls back to ./config.toml and then ~/.config/tunnix/config.toml, so
 /// a developer's own `allow_transfer = true` would silently decide what these
@@ -64,9 +58,9 @@ fn write_empty_config(tmp: &Path, name: &str, section: &str) -> std::path::PathB
 fn start_server(bin: &str, tmp: &Path, port: u16, allow_transfer: bool) -> KillOnDrop {
     let config = write_empty_config(tmp, "server.toml", "server");
     let mut args = vec![
+        "server".to_string(),
         "--config".to_string(),
         config.to_str().unwrap().to_string(),
-        "server".to_string(),
         "--listen".to_string(),
         format!("127.0.0.1:{}", port),
         "-p".to_string(),
@@ -91,9 +85,9 @@ fn start_server(bin: &str, tmp: &Path, port: u16, allow_transfer: bool) -> KillO
 fn run_transfer(bin: &str, tmp: &Path, port: u16, sub: &str, paths: &[&str]) -> bool {
     let config = write_empty_config(tmp, "client.toml", "client");
     let mut args = vec![
+        sub.to_string(),
         "--config".to_string(),
         config.to_str().unwrap().to_string(),
-        sub.to_string(),
         "-s".to_string(),
         format!("http://127.0.0.1:{}", port),
         "-p".to_string(),


### PR DESCRIPTION
Fixes the six relay and teardown bugs surfaced during the rama port review, implemented against the current (non-rama) code. Each fix is independent of that migration.

Every bug here is reproduced by a test that was verified to fail before the fix and pass after.

## Bugs fixed

| # | Bug | Symptom |
|---|-----|---------|
| 1 | Relay collapsed both directions when either one finished | A client that half-closed after its request got **0 of 262144 bytes** of the response |
| 2/3 | Target failure was reported as a clean EOF | A reset upstream looked like a completed response - silent truncation |
| 4 | Terminal `Close`/`Error` lost on a full or replaced SSE queue | The client's relay never learned the target closed, and stranded |
| 5 | Unbounded waits parked relays forever | One stalled local app starved **every** connection on the tunnel |
| 6 | Target writer dropped at target-output EOF | A 16 MiB upload after the target closed its output delivered **0 bytes** |

Bugs 1 and 6 are the two halves of the same story: each direction of a proxied connection now ends on its own.

## Notable details

**Failure vs. success is now structural.** A clean EOF has to be earned by an explicit terminal event; anything else that ends the write loop (session `Reset`, dispatcher dropping a stalled connection) counts as a failure and aborts the connection with a RST. A truncated response reported as complete is silent data corruption, so this is the invariant the whole PR is built around.

**Deduplication, not addition.** Four open-coded copies of the SSE retry loop collapsed into one `send_to_client` call, and two watchdogs into one `await_sse_dead` helper. That duplication is exactly what let the terminal-message path drift out of sync and cause bug 4.

**Two constants that must not collide.** The client's dispatch stall bound runs inline in the SSE read loop, so it is also how long the client can go without reading SSE at all. At the same magnitude as the server's ~30s delivery budget, one stalled consumer would exhaust that budget on unrelated healthy connections and tear them down. It is now 5s, and both constants reference each other.

## Testing

27 tests, up from 21. New coverage: both half-close directions (including a 16 MiB upload that continues after target-output EOF), target failure signalling, terminal-message delivery against a full and a replaced queue, teardown when the client vanishes on both the read and write sides, and dropped-channel truncation.

Timeout-driven tests use `#[tokio::test(start_paused = true)]` so 30s and 6s bounds elapse instantly. `tokio`'s `test-util` is a dev-dependency, and `cargo build --release` was verified to confirm the test clock cannot ship.

Integration tests scrub `*_PROXY` from spawned processes - these talk over loopback and must not traverse a developer's ambient proxy.

## Known issues, not addressed here

- **`tunnix push` exits 0 when the server refuses the transfer.** `test_transfer_denied_when_disabled` fails identically on unmodified `main`; the server gates correctly but the client swallows the rejection. Pre-existing, and the one failing test in the suite.
- **`tests/reconnect_on_url_change.rs` fails in any shell with `HTTP_PROXY` set** - it does not scrub proxy vars the way the new tests do.
- **`handle_send`'s send to the target writer is the last unbounded wait on a hot path.** Left deliberately: it is genuine backpressure and resolves when the target dies. Bounding it means choosing between dropping bytes and killing slow-but-healthy transfers, which is a policy call rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay handling for interrupted connections and half-closed sockets.
  - Prevented incomplete responses from appearing as successful end-of-file events.
  - Preserved full responses and uploads when either side closes its output stream.
  - Surfaced aborted target connections as errors instead of clean disconnects.
  - Added automatic retry support for encrypted server-sent event delivery after reconnects.
  - Preserved SSE data chunks during reconnects.
  - More reliably detects disconnected or idle connections and cleans up stale connections.
  - Prevented stalled connections from blocking event delivery to others.
  - Improved delivery of terminal messages and PTY setup errors during reconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->