### PR TITLE
feat: exit client after max reconnect attempts with no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ password = "your-secret"
 server_url = "https://your-host.example.com"
 password = "your-secret"
 local_addr = "127.0.0.1:7890"
+# reconnect_interval = 3       # seconds to wait before reopening a failed stream
+# max_reconnect_attempts = 3   # consecutive no-data attempts before exiting; 0 = retry forever
 
 [client.headers]
 # Cookie = "..."   # only needed for cookie-authenticated hosts
@@ -242,7 +244,13 @@ This applies to every subcommand, including `push` / `pull` and `remote-exec` �
 
 CLI flags always override config file values. The password can also be supplied via the `TUNNIX_PASSWORD` environment variable.
 
-Changes to `config.toml` are picked up automatically every few seconds — no restart needed. Hot-reloadable fields: `password`, `headers`, `path_prefix`, `root_redirect`, `root_html`, `health_response`. Fields that require a restart: `listen`, `local_addr`, `server_url`, `logging.level`. CLI overrides are never clobbered by file changes.
+Changes to `config.toml` are picked up automatically every few seconds — no restart needed. Hot-reloadable fields: `password`, `headers`, `path_prefix`, `root_redirect`, `root_html`, `health_response`. Fields that require a restart: `listen`, `local_addr`, `server_url`, `logging.level`, `reconnect_interval`, `max_reconnect_attempts`. CLI overrides are never clobbered by file changes.
+
+### When the server goes away
+
+The client reopens the SSE stream on its own, waiting `reconnect_interval` seconds between tries. After `max_reconnect_attempts` consecutive attempts that get no data from the server it logs the reason and exits non-zero, rather than retrying forever behind a proxy port that fails every connection - so a supervisor (systemd, launchd, a shell loop) can decide what to do about it. Any stream that does deliver data resets the count, so ordinary reconnects across a server restart never accumulate toward it. Set `max_reconnect_attempts = 0` to retry forever.
+
+Note the initial connection is not retried at all: if the server is unreachable when the client starts, the health check fails and it exits immediately.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Changes to `config.toml` are picked up automatically every few seconds — no re
 
 ### When the server goes away
 
-The client reopens the SSE stream on its own, waiting `reconnect_interval` seconds between tries. After `max_reconnect_attempts` consecutive attempts that get no data from the server it logs the reason and exits non-zero, rather than retrying forever behind a proxy port that fails every connection - so a supervisor (systemd, launchd, a shell loop) can decide what to do about it. Any stream that does deliver data resets the count, so ordinary reconnects across a server restart never accumulate toward it. Set `max_reconnect_attempts = 0` to retry forever.
+The client reopens the SSE stream on its own, waiting `reconnect_interval` seconds after a failed attempt - or a fixed 1s after a stream that ended cleanly, which usually just means the server dropped the session and a fresh GET will recreate it. After `max_reconnect_attempts` consecutive attempts that get no data from the server it logs the reason and exits non-zero, rather than retrying forever behind a proxy port that fails every connection - so a supervisor (systemd, launchd, a shell loop) can decide what to do about it. Any stream that does deliver data resets the count, so ordinary reconnects across a server restart never accumulate toward it. Set `max_reconnect_attempts = 0` to retry forever.
 
 Note the initial connection is not retried at all: if the server is unreachable when the client starts, the health check fails and it exits immediately.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -55,8 +55,15 @@ password = "change-this-to-a-strong-password"
 # Local proxy address — accepts both SOCKS5 and HTTP proxy on the same port
 local_addr = "127.0.0.1:7890"
 
-# Reconnect interval in seconds (optional)
-# reconnect_interval = 5
+# Seconds to wait before reopening the stream after a failure. Default: 3
+# reconnect_interval = 3
+
+# Consecutive reconnect attempts that may fail to get any data from the server
+# before the client gives up and exits. Any stream that does deliver data
+# resets the count, so this bounds an unbroken run of failures (server down,
+# wrong URL), not reconnects over the tunnel's lifetime. 0 = retry forever.
+# Default: 3
+# max_reconnect_attempts = 3
 
 # Expected response body from server /health. Connection fails if response doesn't match. Default: "ok"
 # health_expected = "ok"

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,9 +79,17 @@ pub struct ClientConfig {
     #[serde(default)]
     pub headers: HashMap<String, String>,
 
-    /// Reconnect interval in seconds
+    /// Seconds to wait before reopening the SSE stream after a failure.
     #[serde(default = "default_reconnect_interval")]
     pub reconnect_interval: u64,
+
+    /// Consecutive reconnect attempts that may fail to get any data from the
+    /// server before the client gives up and exits. Any stream that does
+    /// deliver data resets the count, so this bounds an unbroken run of
+    /// failures (server down, wrong URL), not reconnects over the tunnel's
+    /// lifetime. 0 = retry forever.
+    #[serde(default = "default_max_reconnect_attempts")]
+    pub max_reconnect_attempts: u32,
 
     /// Expected response body from server /health (default: "ok"). Connection fails if mismatch.
     #[serde(default = "default_health_expected")]
@@ -113,7 +121,11 @@ fn default_timeout() -> u64 {
 }
 
 fn default_reconnect_interval() -> u64 {
-    5
+    3
+}
+
+fn default_max_reconnect_attempts() -> u32 {
+    3
 }
 
 fn default_health_response() -> String {
@@ -153,6 +165,7 @@ impl Default for ClientConfig {
             local_addr: default_local_addr(),
             headers: HashMap::new(),
             reconnect_interval: default_reconnect_interval(),
+            max_reconnect_attempts: default_max_reconnect_attempts(),
             health_expected: default_health_expected(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,10 @@ struct ClientArgs {
     /// Custom cookie header (overrides config)
     #[arg(short, long)]
     cookie: Option<String>,
+
+    /// Consecutive failed reconnects before giving up (0 = retry forever)
+    #[arg(long)]
+    max_reconnect_attempts: Option<u32>,
 }
 
 #[cfg(unix)]
@@ -310,6 +314,9 @@ async fn main() -> Result<()> {
             if let Some(local_addr) = ca.local_addr {
                 config.client.local_addr = local_addr;
             }
+            if let Some(max) = ca.max_reconnect_attempts {
+                config.client.max_reconnect_attempts = max;
+            }
             if let Some(cookie) = ca.cookie {
                 config.client.headers.insert("Cookie".to_string(), cookie);
             }
@@ -342,6 +349,8 @@ async fn main() -> Result<()> {
                 crypto,
                 &config.client.headers,
                 &config.client.health_expected,
+                config.client.reconnect_interval,
+                config.client.max_reconnect_attempts,
             )
             .await?;
 
@@ -394,6 +403,8 @@ async fn main() -> Result<()> {
                 crypto,
                 &config.client.headers,
                 &config.client.health_expected,
+                config.client.reconnect_interval,
+                config.client.max_reconnect_attempts,
             )
             .await?;
 
@@ -479,6 +490,8 @@ async fn connect_transfer_tunnel(
         crypto,
         &config.client.headers,
         &config.client.health_expected,
+        config.client.reconnect_interval,
+        config.client.max_reconnect_attempts,
     )
     .await
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1078,9 +1078,10 @@ async fn relay_pty_connection(
 /// relays treat the client as gone.
 ///
 /// A trade between two costs. Too short, and a client that is merely slow to
-/// reconnect loses its idle connections: its reconnect is a fixed 3s sleep
-/// plus a GET that can take several seconds through a reverse proxy, and 6s
-/// cleared the sleep with little to spare. Too long, and a client that really
+/// reconnect loses its idle connections: its reconnect is a sleep of
+/// `client.reconnect_interval` (3s by default) plus a GET that can take
+/// several seconds through a reverse proxy, and 6s cleared the sleep with
+/// little to spare. Too long, and a client that really
 /// is gone keeps its PTY children running and its target sockets held for the
 /// whole wait. 10s leaves the GET 7s and still reaps within seconds.
 ///
@@ -1152,8 +1153,10 @@ const SEND_ATTEMPTS: u32 = 50;
 /// than to a fixed backoff: a *full* channel (client stalled) costs the 500ms
 /// send timeout, but a *closed* one (client mid-reconnect) fails instantly, and
 /// pacing by attempt count alone gave a reconnecting client 50 x 100ms = 5s
-/// against a stalled client's 30s. The client's reconnect is a 3s sleep plus a
-/// GET, so 5s was tearing down healthy connections across ordinary reconnects.
+/// against a stalled client's 30s. The client's reconnect is a sleep of
+/// `client.reconnect_interval` (3s by default) plus a GET, so 5s was tearing
+/// down healthy connections across ordinary reconnects. A client configured
+/// with a much larger interval trades that margin away.
 const SEND_ATTEMPT_INTERVAL: Duration = Duration::from_millis(600);
 
 /// `send_to_client` with an explicit attempt budget. Only teardown paths that

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -20,6 +20,10 @@ const SSE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// that long under network congestion, and this also covers first-frame
 /// processing before sse_ready fires.
 const RECONNECT_WAIT: Duration = Duration::from_secs(20);
+/// Delay before reopening a stream that ended cleanly. Usually the server
+/// dropped our session (restart or eviction) and a fresh GET recreates it, so
+/// this is deliberately shorter than the configured post-error interval.
+const CLEAN_END_RETRY: Duration = Duration::from_secs(1);
 /// Per-connection event queue depth. Deep enough that a merely slow local app
 /// keeps draining without stalling dispatch.
 const CONN_CHANNEL_CAPACITY: usize = 256;
@@ -65,6 +69,11 @@ pub struct Tunnel {
     pub response_channels: Arc<Mutex<HashMap<u32, mpsc::Sender<TunnelEvent>>>>,
     pub reconnect_signal: Arc<Notify>,
     sse_ready: Arc<Notify>,
+    /// How long to wait before reopening the stream after a failure.
+    retry_interval: Duration,
+    /// Consecutive no-data attempts tolerated before the client exits; 0 =
+    /// retry forever. See the give-up branch in the reconnect loop.
+    max_reconnect_attempts: u32,
 }
 
 impl Tunnel {
@@ -74,6 +83,8 @@ impl Tunnel {
         crypto: Arc<Crypto>,
         headers: &HashMap<String, String>,
         health_expected: &str,
+        reconnect_interval: u64,
+        max_reconnect_attempts: u32,
     ) -> Result<Arc<Self>> {
         let session_id = format!("{:016x}", rand::random::<u64>());
 
@@ -92,6 +103,8 @@ impl Tunnel {
             response_channels: Arc::new(Mutex::new(HashMap::new())),
             reconnect_signal: Arc::new(Notify::new()),
             sse_ready: Arc::new(Notify::new()),
+            retry_interval: Duration::from_secs(reconnect_interval),
+            max_reconnect_attempts,
         });
 
         // Test connection with health check
@@ -127,19 +140,53 @@ impl Tunnel {
             // case signal on any event to avoid stalling `send_message`'s
             // retry for the full RECONNECT_WAIT timeout.
             let mut is_reconnect = false;
+            // Consecutive attempts that never got a byte out of the stream.
+            // Any stream that *did* deliver data resets this, so the budget
+            // bounds an unbroken run of failures (server down, wrong URL) and
+            // not reconnects over the tunnel's lifetime: a long-lived client
+            // legitimately reconnects many times as the server restarts or
+            // evicts its session, and must survive all of them.
+            let mut failures: u32 = 0;
             loop {
-                let res = tunnel_clone.sse_read_loop(is_reconnect).await;
+                let mut progress = false;
+                let res = tunnel_clone.sse_read_loop(is_reconnect, &mut progress).await;
                 is_reconnect = true;
-                match res {
-                    Err(e) if e.to_string().contains("forced reconnect") => continue,
-                    Err(e) => {
-                        error!("SSE stream error: {}, reconnecting in 3s...", e);
-                        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                    }
-                    Ok(()) => {
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    }
+
+                // A forced reconnect is deliberate (config reload, or a send
+                // failure asking for a fresh stream), not a failure to reach
+                // the server: it neither counts nor waits.
+                if matches!(&res, Err(e) if e.to_string().contains("forced reconnect")) {
+                    continue;
                 }
+
+                if progress {
+                    failures = 0;
+                } else {
+                    failures += 1;
+                }
+
+                if let Err(e) = &res {
+                    error!("SSE stream error: {}", e);
+                }
+
+                let max = tunnel_clone.max_reconnect_attempts;
+                if max != 0 && failures >= max {
+                    // The reconnect task is the only thing holding the tunnel
+                    // up, so returning here would leave the proxy listening
+                    // and failing every connection. Exit loudly instead:
+                    // tracing writes straight to stderr/the log file, so
+                    // nothing buffered is lost.
+                    error!(
+                        "no data from the server across {} consecutive attempt(s); giving up. \
+                         Raise client.max_reconnect_attempts (0 = retry forever) to keep trying.",
+                        failures
+                    );
+                    std::process::exit(1);
+                }
+
+                let wait = if res.is_ok() { CLEAN_END_RETRY } else { tunnel_clone.retry_interval };
+                warn!("reconnecting in {:?} (consecutive failures: {})", wait, failures);
+                tokio::time::sleep(wait).await;
             }
         });
 
@@ -154,7 +201,9 @@ impl Tunnel {
     }
 
     /// Read SSE events and dispatch to connection handlers
-    async fn sse_read_loop(&self, is_reconnect: bool) -> Result<()> {
+    /// Sets `progress` once the stream has yielded a byte: proof the server is
+    /// alive and streaming, which is what clears the reconnect budget.
+    async fn sse_read_loop(&self, is_reconnect: bool, progress: &mut bool) -> Result<()> {
         let hot = self.hot.load();
         let sid = self.session_id.read().await;
         let url = format!("{}/stream/{}", hot.server_base_url, *sid);
@@ -216,7 +265,11 @@ impl Tunnel {
             tokio::select! {
                 chunk = tokio::time::timeout(Duration::from_secs(30), stream.next()) => {
                     let chunk = match chunk {
-                        Ok(Some(c)) => c?,
+                        Ok(Some(c)) => {
+                            let c = c?;
+                            *progress = true;
+                            c
+                        }
                         Ok(None) => break,
                         Err(_) => {
                             warn!("SSE read timeout, reconnecting");
@@ -499,6 +552,8 @@ pub(crate) mod tests {
             response_channels: Arc::new(Mutex::new(HashMap::new())),
             reconnect_signal: Arc::new(Notify::new()),
             sse_ready: Arc::new(Notify::new()),
+            retry_interval: Duration::from_secs(3),
+            max_reconnect_attempts: 3,
         }
     }
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -20,6 +20,10 @@ const SSE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// that long under network congestion, and this also covers first-frame
 /// processing before sse_ready fires.
 const RECONNECT_WAIT: Duration = Duration::from_secs(20);
+/// How long the client waits for any byte on the SSE stream before declaring
+/// it dead. The server sends a keepalive comment every 15s, so this tolerates
+/// one missed keepalive before giving up on the connection.
+const SSE_READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// Delay before reopening a stream that ended cleanly. Usually the server
 /// dropped our session (restart or eviction) and a fresh GET recreates it, so
 /// this is deliberately shorter than the configured post-error interval.
@@ -263,7 +267,7 @@ impl Tunnel {
 
         loop {
             tokio::select! {
-                chunk = tokio::time::timeout(Duration::from_secs(30), stream.next()) => {
+                chunk = tokio::time::timeout(SSE_READ_TIMEOUT, stream.next()) => {
                     let chunk = match chunk {
                         Ok(Some(c)) => {
                             let c = c?;
@@ -271,10 +275,12 @@ impl Tunnel {
                             c
                         }
                         Ok(None) => break,
-                        Err(_) => {
-                            warn!("SSE read timeout, reconnecting");
-                            break;
-                        }
+                        // Not a clean end: the server owes us a keepalive
+                        // every 15s, so silence this long is a failure. Break
+                        // here and the outer loop would read it as a dropped
+                        // session and retry after CLEAN_END_RETRY instead of
+                        // backing off by the configured interval.
+                        Err(_) => anyhow::bail!("no data on the SSE stream for {:?}", SSE_READ_TIMEOUT),
                     };
                     let text = String::from_utf8_lossy(&chunk);
                     buffer.push_str(&text);

--- a/tests/reconnect_gives_up.rs
+++ b/tests/reconnect_gives_up.rs
@@ -1,0 +1,287 @@
+//! The client's reconnect loop used to retry forever at a flat interval, so a
+//! server that never came back left the process alive, logging an error every
+//! few seconds and failing every proxied connection. It now gives up after
+//! `client.max_reconnect_attempts` consecutive attempts that get no data.
+//!
+//! The subtle half is the reset: reconnects are routine on a long-lived tunnel
+//! (the server restarts, or evicts the session), so the budget must bound an
+//! unbroken run of failures and not reconnects over the tunnel's lifetime.
+//! Both halves are covered here.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+mod common;
+use crate::common::no_inherited_proxy;
+
+fn find_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind");
+    listener.local_addr().unwrap().port()
+}
+
+fn health_check(port: u16) -> bool {
+    let addr = format!("127.0.0.1:{}", port);
+    if let Ok(mut stream) = TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(1)) {
+        let req = "GET /health HTTP/1.0\r\n\r\n";
+        let _ = stream.write_all(req.as_bytes());
+        let mut resp = String::new();
+        if stream.read_to_string(&mut resp).is_ok() {
+            return resp.contains("200 OK");
+        }
+    }
+    false
+}
+
+fn wait_for_server(port: u16, timeout_ms: u64) -> bool {
+    let start = Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        if health_check(port) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+fn read_log(log_path: &Path) -> String {
+    let mut buf = String::new();
+    std::fs::File::open(log_path)
+        .and_then(|mut f| f.read_to_string(&mut buf))
+        .ok();
+    buf
+}
+
+/// Wait for a substring to appear in a log file.
+fn wait_for_log(log_path: &Path, target: &str, timeout_ms: u64) -> bool {
+    let start = Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        if read_log(log_path).contains(target) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+/// Wait for `target` to appear at least `n` times.
+fn wait_for_log_count(log_path: &Path, target: &str, n: usize, timeout_ms: u64) -> bool {
+    let start = Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        if read_log(log_path).matches(target).count() >= n {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn tmp_dir(name: &str) -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join(name);
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("failed to create temp dir");
+    tmp
+}
+
+/// The server falls back to ./config.toml and then ~/.config/tunnix/config.toml
+/// when no --config is given, so every server here gets an empty one of its
+/// own: an ambient path_prefix would change what these tests exercise.
+fn write_server_config(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("server.toml");
+    std::fs::write(&path, "[server]\n").expect("write server config");
+    path
+}
+
+fn spawn_server(bin: &str, server_config: &Path, port: u16) -> KillOnDrop {
+    let mut cmd = Command::new(bin);
+    cmd.args([
+        "server",
+        "--config",
+        server_config.to_str().unwrap(),
+        "--listen",
+        &format!("127.0.0.1:{}", port),
+        "-p",
+        "test",
+    ]);
+    no_inherited_proxy(&mut cmd);
+    KillOnDrop(
+        cmd.stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start server"),
+    )
+}
+
+fn spawn_client(bin: &str, config: &Path, log: &Path) -> Child {
+    let mut cmd = Command::new(bin);
+    cmd.args([
+        "client",
+        "--config",
+        config.to_str().unwrap(),
+        "--log",
+        log.to_str().unwrap(),
+        "-p",
+        "test",
+    ]);
+    no_inherited_proxy(&mut cmd);
+    cmd.stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to start client")
+}
+
+fn write_client_config(path: &Path, server_port: u16, proxy_port: u16, max_attempts: u32) {
+    let content = format!(
+        r#"[client]
+server_url = "http://127.0.0.1:{server_port}"
+local_addr = "127.0.0.1:{proxy_port}"
+password = ""
+reconnect_interval = 1
+max_reconnect_attempts = {max_attempts}
+"#,
+    );
+    std::fs::write(path, content).expect("failed to write config");
+}
+
+/// Wait for the child to exit, returning its status.
+fn wait_for_exit(child: &mut Child, timeout_ms: u64) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => thread::sleep(Duration::from_millis(100)),
+            Err(e) => panic!("try_wait failed: {}", e),
+        }
+    }
+    None
+}
+
+#[test]
+fn test_client_exits_after_max_reconnect_attempts() {
+    let bin = std::env!("CARGO_BIN_EXE_tunnix");
+    let tmp = tmp_dir("tunnix_itest_giveup");
+    let server_config = write_server_config(&tmp);
+    let config_path = tmp.join("config.toml");
+    let log_path = tmp.join("client.log");
+
+    let port = find_free_port();
+    let proxy_port = find_free_port();
+    write_client_config(&config_path, port, proxy_port, 2);
+
+    let server = spawn_server(bin, &server_config, port);
+    assert!(wait_for_server(port, 10_000), "server did not become ready");
+
+    let mut client = spawn_client(bin, &config_path, &log_path);
+    assert!(
+        wait_for_log(&log_path, "Tunnel established", 15_000),
+        "client did not establish tunnel:\n{}",
+        read_log(&log_path)
+    );
+
+    // Take the server away for good. Two failed attempts at a 1s interval
+    // should be spent in a few seconds; allow generous slack for a loaded CI
+    // box, but far less than the forever the old loop would have run for.
+    drop(server);
+
+    let status = wait_for_exit(&mut client, 30_000);
+    let log = read_log(&log_path);
+    let status = match status {
+        Some(s) => s,
+        None => {
+            let _ = client.kill();
+            panic!("client kept retrying instead of giving up:\n{}", log);
+        }
+    };
+
+    assert!(!status.success(), "expected a failure exit, got {:?}", status);
+    assert!(
+        log.contains("giving up"),
+        "expected the give-up reason in the log:\n{}",
+        log
+    );
+    assert!(
+        log.contains("2 consecutive attempt(s)"),
+        "expected exactly the configured budget to be spent:\n{}",
+        log
+    );
+}
+
+#[test]
+fn test_healthy_reconnect_resets_the_budget() {
+    let bin = std::env!("CARGO_BIN_EXE_tunnix");
+    let tmp = tmp_dir("tunnix_itest_giveup_reset");
+    let server_config = write_server_config(&tmp);
+    let config_path = tmp.join("config.toml");
+    let log_path = tmp.join("client.log");
+
+    let port = find_free_port();
+    let proxy_port = find_free_port();
+    write_client_config(&config_path, port, proxy_port, 3);
+
+    let server = spawn_server(bin, &server_config, port);
+    assert!(wait_for_server(port, 10_000), "server did not become ready");
+
+    let mut client = spawn_client(bin, &config_path, &log_path);
+    assert!(
+        wait_for_log(&log_path, "Tunnel established", 15_000),
+        "client did not establish tunnel:\n{}",
+        read_log(&log_path)
+    );
+
+    // Bounce the server on the same port more times than the budget allows.
+    // Each bounce costs the client a reconnect, but every one of them lands on
+    // a live server and gets a Reset frame, so no two failures are
+    // consecutive: a lifetime-counting budget would have killed the client on
+    // the third bounce.
+    let mut current = Some(server);
+    for bounce in 1..=4 {
+        drop(current.take());
+        current = Some(spawn_server(bin, &server_config, port));
+        assert!(
+            wait_for_server(port, 10_000),
+            "server did not come back for bounce {}",
+            bounce
+        );
+        // +1 for the initial connect.
+        assert!(
+            wait_for_log_count(&log_path, "SSE stream connected", bounce + 1, 20_000),
+            "client did not reconnect after bounce {}:\n{}",
+            bounce,
+            read_log(&log_path)
+        );
+        assert!(
+            client.try_wait().expect("try_wait failed").is_none(),
+            "client gave up across healthy reconnects:\n{}",
+            read_log(&log_path)
+        );
+    }
+
+    // Same client, server now gone for good: the budget still applies.
+    drop(current.take());
+    let status = wait_for_exit(&mut client, 30_000);
+    let log = read_log(&log_path);
+    match status {
+        Some(s) => assert!(!s.success(), "expected a failure exit, got {:?}", s),
+        None => {
+            let _ = client.kill();
+            panic!("client kept retrying instead of giving up:\n{}", log);
+        }
+    }
+    assert!(
+        log.contains("3 consecutive attempt(s)"),
+        "expected the full budget to be spent after the final kill:\n{}",
+        log
+    );
+}

--- a/tests/reconnect_gives_up.rs
+++ b/tests/reconnect_gives_up.rs
@@ -142,13 +142,19 @@ fn spawn_client(bin: &str, config: &Path, log: &Path) -> Child {
         .expect("failed to start client")
 }
 
-fn write_client_config(path: &Path, server_port: u16, proxy_port: u16, max_attempts: u32) {
+fn write_client_config(
+    path: &Path,
+    server_port: u16,
+    proxy_port: u16,
+    interval: u64,
+    max_attempts: u32,
+) {
     let content = format!(
         r#"[client]
 server_url = "http://127.0.0.1:{server_port}"
 local_addr = "127.0.0.1:{proxy_port}"
 password = ""
-reconnect_interval = 1
+reconnect_interval = {interval}
 max_reconnect_attempts = {max_attempts}
 "#,
     );
@@ -178,7 +184,7 @@ fn test_client_exits_after_max_reconnect_attempts() {
 
     let port = find_free_port();
     let proxy_port = find_free_port();
-    write_client_config(&config_path, port, proxy_port, 2);
+    write_client_config(&config_path, port, proxy_port, 1, 2);
 
     let server = spawn_server(bin, &server_config, port);
     assert!(wait_for_server(port, 10_000), "server did not become ready");
@@ -205,7 +211,14 @@ fn test_client_exits_after_max_reconnect_attempts() {
         }
     };
 
-    assert!(!status.success(), "expected a failure exit, got {:?}", status);
+    // Exactly 1: `!success()` would also accept a panic or a signal kill.
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "expected a clean exit(1), got {:?}:\n{}",
+        status,
+        log
+    );
     assert!(
         log.contains("giving up"),
         "expected the give-up reason in the log:\n{}",
@@ -228,7 +241,7 @@ fn test_healthy_reconnect_resets_the_budget() {
 
     let port = find_free_port();
     let proxy_port = find_free_port();
-    write_client_config(&config_path, port, proxy_port, 3);
+    write_client_config(&config_path, port, proxy_port, 2, 3);
 
     let server = spawn_server(bin, &server_config, port);
     assert!(wait_for_server(port, 10_000), "server did not become ready");
@@ -248,6 +261,20 @@ fn test_healthy_reconnect_resets_the_budget() {
     let mut current = Some(server);
     for bounce in 1..=4 {
         drop(current.take());
+
+        // Wait for the client to actually notice, and to say that the stream
+        // it lost had delivered data. "SSE stream connected" would not do: it
+        // is logged as soon as the GET returns headers, before a single byte
+        // is read, so it cannot tell a stream that carried a Reset frame from
+        // one that merely opened. Only a zeroed count proves `progress` was
+        // set - a run of dead attempts logs 1, 2, 3 instead.
+        assert!(
+            wait_for_log_count(&log_path, "consecutive failures: 0", bounce, 20_000),
+            "bounce {} broke a stream that had never delivered data:\n{}",
+            bounce,
+            read_log(&log_path)
+        );
+
         current = Some(spawn_server(bin, &server_config, port));
         assert!(
             wait_for_server(port, 10_000),
@@ -273,7 +300,13 @@ fn test_healthy_reconnect_resets_the_budget() {
     let status = wait_for_exit(&mut client, 30_000);
     let log = read_log(&log_path);
     match status {
-        Some(s) => assert!(!s.success(), "expected a failure exit, got {:?}", s),
+        Some(s) => assert_eq!(
+            s.code(),
+            Some(1),
+            "expected a clean exit(1), got {:?}:\n{}",
+            s,
+            log
+        ),
         None => {
             let _ = client.kill();
             panic!("client kept retrying instead of giving up:\n{}", log);


### PR DESCRIPTION
Addresses the issue of the client retrying infinitely to reconnect when the remote is down.

### Key Changes
- Configurable Reconnection Cap: Added max_reconnect_attempts (defaults to 3) which limits consecutive failed reconnect attempts with no data. Set to 0 to retry forever (the old behavior).
- Failure Count Reset: Uses a progress flag to reset the consecutive failures count to 0 once any data is successfully streamed. This ensures healthy routine reconnects over a tunnel's lifetime are unaffected.
- Graceful Termination: Instead of quietly locking up the proxy and spinning forever, the client cleanly logs a final error and exits with status code 1, letting supervisor daemons/scripts handle the restart/alerting.
- Enabled Config Variable: Wired reconnect_interval (defaults to 3 seconds) which was previously parsed but ignored.
- CLI Options: Added the --max-reconnect-attempts parameter.
- Integration Tests: Added tests/reconnect_gives_up.rs to verify client exit under persistent server loss and reset logic during successful bounces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable SSE reconnect intervals, with a default of 3 seconds.
  - Added a limit for consecutive failed reconnect attempts; set it to 0 to retry indefinitely.
  - Successful data delivery resets the consecutive-failure count.
  - The client now exits after exceeding the configured retry limit.

- **Documentation**
  - Documented reconnect timing, retry behavior, exit-on-failure semantics, and restart requirements for configuration changes.
  - Clarified that the initial connection is not retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->